### PR TITLE
Remove link to CalendarServer-changes list

### DIFF
--- a/MailingLists.md
+++ b/MailingLists.md
@@ -12,5 +12,3 @@ We have the following mailing lists set up:
   * This mailing list is for users of the Calendar Server. It is the main forum for asking questions about installing, configuring and administering a Calendar Server.
 * [CalendarServer-dev](http://lists.macosforge.org/mailman/listinfo/calendarserver-dev)
   * This mailing list is for developers of the Calendar Server. It is the main forum for engineering discussions, including design directions, ways of extending the server, and reviewing code.
-* ​[CalendarServer-changes](http://lists.macosforge.org/mailman/listinfo/calendarserver-changes)
-  * This mailing list is for developers of the Calendar Server. Notifications of changes to the Calendar Server source repository are sent here, which facilitates code review by developers. This is not a discussion list; posting to this list is not permitted.


### PR DESCRIPTION
Users should subscribe to GitHub notifications instead.
