### PR TITLE
Web site improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/_site/
+/Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# www.calendarserver.org
+
+This branch contains the [www.calendarserver.org](https://www.calendarserver.org) web site.
+
+## Testing changes locally
+
+You should test any changes to the web site locally before pushing.
+
+In the Terminal, `cd` to the root directory of your clone.
+
+### Install Ruby, bundler, and the GitHub Pages gems
+
+Make sure you have Ruby 2.0.0 or greater:
+
+    ruby --version
+
+Install the bundler gem:
+
+    gem install bundler
+
+Install the bundle of gems used by GitHub Pages:
+
+    bundle install
+
+If it's been awhile since you installed the bundle, update it:
+
+    bundle update
+
+### Test the web site
+
+Start a local web server by running:
+
+    bundle exec jekyll serve --baseurl ''
+
+Now you can access <http://127.0.0.1:4000> in your web browser to see the web site. When you make changes to your clone, your local site will automatically update. When done testing, press <kbd>Ctrl-C</kbd> to stop the local web server.
+
+Changes to \_config.yml are not automatically reflected. If you change \_config.yml, stop and start the local web server to see those changes take effect.
+
+---
+
+These instructions are based on [GitHub's instructions](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/).

--- a/_config.yml
+++ b/_config.yml
@@ -5,5 +5,10 @@ defaults:
       path: ""
     values:
       layout: "default"
+exclude:
+  - .gitignore
+  - Gemfile
+  - Gemfile.lock
+  - README.md
 title: "Calendar and Contact Server"
 url: "https://www.calendarserver.org"

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,9 @@
+baseurl: ""
 defaults:
   -
     scope:
       path: ""
     values:
       layout: "default"
+title: "Calendar and Contact Server"
+url: "https://www.calendarserver.org"

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,3 +1,4 @@
+{% assign page_url_parts = page.url | split: '/' %}
 <nav class="navbar navbar-default">
   <div class="container">
     <div class="navbar-header">

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-default">
   <div class="container">
     <div class="navbar-header">
-      <a class="navbar-brand" href="{{ '/index.html' | prepend: relative_root_url }}">Calendar and Contacts Server</a>
+      <a class="navbar-brand" href="{{ '/index.html' | prepend: site.baseurl }}">{{ site.title | escape }}</a>
     </div>
   </div>
 </nav>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,0 +1,7 @@
+<nav class="navbar navbar-default">
+  <div class="container">
+    <div class="navbar-header">
+      <a class="navbar-brand" href="{{ '/index.html' | prepend: relative_root_url }}">Calendar and Contacts Server</a>
+    </div>
+  </div>
+</nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ page.title }}</title>
+    <title>{{ page.title | escape }}</title>
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link href="{{ '/styles.css' | prepend: relative_root_url }}" rel="stylesheet">
     <!--[if lt IE 9]>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,13 +16,7 @@
     <![endif]-->
   </head>
   <body>
-    <nav class="navbar navbar-default">
-      <div class="container">
-        <div class="navbar-header">
-          <a class="navbar-brand" href="index.html">Calendar and Contacts Server</a>
-        </div>
-      </div>
-    </nav>
+    {% include navbar.html %}
     <div class="container">
       <div class="row">
         <div class="col-md-12">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,3 +1,6 @@
+{% assign page_url_parts = page.url | split: '/' %}
+{% assign page_url_level = page_url_parts | size %}
+{% capture relative_root_url %}{% if page_url_level < 2 %}.{% else %}{% for i in (2..page_url_level) %}..{% if i < page_url_level %}/{% endif %}{% endfor %}{% endif %}{% endcapture %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -6,6 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title }}</title>
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <link href="{{ '/styles.css' | prepend: relative_root_url }}" rel="stylesheet">
     <!--[if lt IE 9]>
       <script src="https://cdn.jsdelivr.net/html5shiv/3.7.3/html5shiv.min.js" integrity="sha256-3Jy/GbSLrg0o9y5Z5n1uw0qxZECH7C6OQpVBgNFYa0g=" crossorigin="anonymous"></script>
       <script src="https://cdn.jsdelivr.net/respond/1.4.2/respond.min.js" integrity="sha256-g6iAfvZp+nDQ2TdTR/VVKJf3bGro4ub5fvWSWVRi2NE=" crossorigin="anonymous"></script>
@@ -26,7 +30,7 @@
         </div>
       </div>
     </div>
-    <footer>
+    <footer class="sticky-footer">
       <div class="container">
         <p class="text-muted">Copyright &copy; {{ 'now' | date: "%Y" }} Apple Inc. All rights reserved.</p>
       </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,7 @@
     <div class="container">
       <div class="row">
         <div class="col-md-12">
-          {{ page.content }}
+          {{ content }}
         </div>
       </div>
     </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,6 +1,4 @@
 {% assign page_url_parts = page.url | split: '/' %}
-{% assign page_url_level = page_url_parts | size %}
-{% capture relative_root_url %}{% if page_url_level < 2 %}.{% else %}{% for i in (2..page_url_level) %}..{% if i < page_url_level %}/{% endif %}{% endfor %}{% endif %}{% endcapture %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -9,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title | escape }}</title>
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <link href="{{ '/styles.css' | prepend: relative_root_url }}" rel="stylesheet">
+    <link href="{{ '/styles.css' | prepend: site.baseurl }}" rel="stylesheet">
     <!--[if lt IE 9]>
       <script src="https://cdn.jsdelivr.net/html5shiv/3.7.3/html5shiv.min.js" integrity="sha256-3Jy/GbSLrg0o9y5Z5n1uw0qxZECH7C6OQpVBgNFYa0g=" crossorigin="anonymous"></script>
       <script src="https://cdn.jsdelivr.net/respond/1.4.2/respond.min.js" integrity="sha256-g6iAfvZp+nDQ2TdTR/VVKJf3bGro4ub5fvWSWVRi2NE=" crossorigin="anonymous"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,9 @@
     </div>
     <footer class="sticky-footer">
       <div class="container">
-        <p class="text-muted">Copyright &copy; {{ 'now' | date: "%Y" }} Apple Inc. All rights reserved.</p>
+        <ul class="list-inline">
+          <li><p class="text-muted">Copyright &copy; {{ "now" | date: "%Y" }} Apple Inc. All rights reserved.</p></li>
+        </ul>
       </div>
     </footer>
   </body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,4 +1,3 @@
-{% assign page_url_parts = page.url | split: '/' %}
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,9 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title }}</title>
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!--[if lt IE 9]>
+      <script src="https://cdn.jsdelivr.net/html5shiv/3.7.3/html5shiv.min.js" integrity="sha256-3Jy/GbSLrg0o9y5Z5n1uw0qxZECH7C6OQpVBgNFYa0g=" crossorigin="anonymous"></script>
+      <script src="https://cdn.jsdelivr.net/respond/1.4.2/respond.min.js" integrity="sha256-g6iAfvZp+nDQ2TdTR/VVKJf3bGro4ub5fvWSWVRi2NE=" crossorigin="anonymous"></script>
+    <![endif]-->
   </head>
   <body>
     <nav class="navbar navbar-default">

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,16 @@
+html {
+  min-height: 100%;
+  position: relative;
+}
+
+body {
+  margin-bottom: 3em;
+}
+
+.sticky-footer {
+  bottom: 0;
+  height: 3em;
+  padding: 1em 0;
+  position: absolute;
+  width: 100%;
+}


### PR DESCRIPTION
Here are some improvements to the web site.
- With the latest GitHub Pages update, `page.content` is now the unrendered markdown, while `content` is the rendered html.
- Update the tags in the `<head>` section to match [Bootstrap's recommendations](http://getbootstrap.com/getting-started/#template).
- Use a [sticky footer](http://getbootstrap.com/examples/sticky-footer/) so the footer stays at the bottom of the window, even if there isn't enough content to fill the window.
- Move the navbar to an include file for easier future editing.
