### PR TITLE
Allow checkdatabaseschema.py to work with non-standard db name and password

### DIFF
--- a/calendarserver/tools/checkdatabaseschema.py
+++ b/calendarserver/tools/checkdatabaseschema.py
@@ -35,6 +35,7 @@ USERNAME = "caldav"
 DATABASENAME = "caldav"
 PGSOCKETDIR = "127.0.0.1"
 SCHEMADIR = "./txdav/common/datastore/sql_schema/"
+CONNECTIONURI = ""
 
 # Executables:
 PSQL = "../postgresql/_root/bin/psql"
@@ -42,11 +43,12 @@ PSQL = "../postgresql/_root/bin/psql"
 
 def usage(e=None):
     name = os.path.basename(sys.argv[0])
-    print("usage: %s [options] username" % (name,))
+    print("usage: %s [options]" % (name,))
     print("")
     print(" Check calendar server postgres database and schema")
     print("")
     print("options:")
+    print("  -c: connection URI [postgresql://user:password@hostname:port/dbname]")
     print("  -d: path to server's sql_schema directory [./txdav/common/datastore/sql_schema/]")
     print("  -k: postgres socket path (value for psql -h argument [127.0.0.1])")
     print("  -p: location of psql tool if not on PATH already [psql]")
@@ -78,6 +80,13 @@ def execSQL(title, stmt, verbose=False):
         "-t",
         "-c", stmt,
     ]
+    if CONNECTIONURI:
+        cmdArgs = [
+            PSQL,
+            "-t",
+            CONNECTIONURI,
+            "-c", stmt,
+        ]
     try:
         if verbose:
             print("\n{}".format(title))
@@ -259,7 +268,7 @@ def error(s):
 def main():
     try:
         (optargs, _ignore_args) = getopt(
-            sys.argv[1:], "d:hk:p:vx", [
+            sys.argv[1:], "c:d:hk:p:vx", [
                 "help",
                 "verbose",
             ],
@@ -269,11 +278,13 @@ def main():
 
     verbose = False
 
-    global SCHEMADIR, PGSOCKETDIR, PSQL
+    global SCHEMADIR, PGSOCKETDIR, PSQL, CONNECTIONURI
 
     for opt, arg in optargs:
         if opt in ("-h", "--help"):
             usage()
+        elif opt in ("-c",):
+            CONNECTIONURI = arg
         elif opt in ("-d",):
             SCHEMADIR = arg
         elif opt in ("-k",):


### PR DESCRIPTION
Remove confusing text stating that username is a required argument  to run this tool. Add connection URI to enable non-standard configurations of database names, users, passwords, etc.

By submitting a request, you represent that you have the right to license
your contribution to Apple and the community, and agree that your
contributions are licensed under the [Apache License Version 2.0](LICENSE.txt).

For existing files modified by your request, you represent that you have
retained any existing copyright notices and licensing terms. For each new
file in your request, you represent that you have added to the file a
copyright notice (including the year and the copyright owner's name) and the
Calendar and Contacts Server's licensing terms.

Before submitting the request, please make sure that your request follows
the [Calendar and Contacts Server's guidelines for contributing
code](../../../ccs-calendarserver/blob/master/HACKING.rst).
