### PR TITLE
Check to ensure PSQL is available running command

### DIFF
--- a/calendarserver/tools/checkdatabaseschema.py
+++ b/calendarserver/tools/checkdatabaseschema.py
@@ -303,6 +303,10 @@ def main():
         else:
             raise NotImplementedError(opt)
 
+    if not os.access(PSQL, os.X_OK):
+        sys.stderr.write("Executable copy of PSQL not found at {}. Exiting\n".format(PSQL))
+        sys.exit(0)
+        
     # Retrieve the db_version number of the installed schema
     try:
         db_version = getSchemaVersion(verbose=verbose)

--- a/doc/Admin/Guide.rst
+++ b/doc/Admin/Guide.rst
@@ -80,9 +80,10 @@ Ubuntu 13.10 server:
 ::
 
  sudo apt-get install build-essential git python-setuptools curl \
- libssl-dev libreadline6-dev python-dev libkrb5-dev
+ libssl-dev libreadline6-dev python-dev libkrb5-dev libffi-dev \
+ libldap2-dev libsasl2-dev zlib1g-dev
 
-Next, run ``bin/develop`` to get the remaining dependencies
+Next, run ``bin/develop`` to get the remaining dependencies (note that for some releases on some distributions it may be necessary to run ``/bin/bash bin/develop`` to force the script to run under the bash shell)
 
 (to be continued...)
 


### PR DESCRIPTION
Tool currently crashes if PSQL isn't found in the path specified. Should gracefully exit with an error instead.

By submitting a request, you represent that you have the right to license
your contribution to Apple and the community, and agree that your
contributions are licensed under the [Apache License Version 2.0](LICENSE.txt).

For existing files modified by your request, you represent that you have
retained any existing copyright notices and licensing terms. For each new
file in your request, you represent that you have added to the file a
copyright notice (including the year and the copyright owner's name) and the
Calendar and Contacts Server's licensing terms.

Before submitting the request, please make sure that your request follows
the [Calendar and Contacts Server's guidelines for contributing
code](../../../ccs-calendarserver/blob/master/HACKING.rst).
