### PR TITLE
Release/calendar server 9.1 docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.git
+data
+conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:jessie-slim
+
+# Install prerequisites
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get install -y libsasl2-dev python-dev libldap2-dev libssl-dev curl \
+                       make gcc bzip2 libreadline-dev zlib1g-dev libkrb5-dev \
+                       python-pip libffi-dev libffi6 memcached git python-xattr
+
+ADD . /opt/ccs
+WORKDIR /opt/ccs
+
+# Run configuration script
+RUN ./bin/develop
+
+# Create a new user. The UUID can be changed, but it is necessary to set one if
+# you want to mount the /data folder as a Docker volume
+RUN useradd ccs-user -d /opt/ccs -u 1001
+RUN chown -R ccs-user:ccs-user /opt/ccs
+
+USER ccs-user
+CMD ["./bin/run", "-n"]

--- a/bin/_build.sh
+++ b/bin/_build.sh
@@ -203,7 +203,7 @@ init_build () {
   fi;
 
   default_requirements="${wd}/requirements-default.txt";
-  use_openssl="true";
+  use_openssl="false";
 
   # Use SecureTransport instead of OpenSSL if possible, unless told otherwise
   if [ -z "${USE_OPENSSL-}" ]; then 


### PR DESCRIPTION
Hello!

This PR is not meant to be merged straight in, but to server as a discussion base :)

I've set up [a Dockerfile for the calendarserver](http://www.uponmyshoulder.com/blog/2017/apple-contact-calendar-server-dockerised/), is that of interest to you, dear maintainers?

If so...
- Could you look through this Dockerfile and tell me whether the way it's built suits you, or whether there's things that should be fixed?
- I had to disable OpenSSL in the script -- we should probably make that configurable, because this possibly breaks the base script
- Should we put this Dockerfile the base folder and make it a bona fide supported way of installing the calendarserver?
- Should we integrate with Docker Hub to provide official images?

Thanks!

- Florent