### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/bin/keychain_init.py
+++ b/bin/keychain_init.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 ##
 
+from __future__ import print_function
 from subprocess import Popen, PIPE, STDOUT
 import os
 import re

--- a/bin/keychain_unlock.py
+++ b/bin/keychain_unlock.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 ##
 
+from __future__ import print_function
 from subprocess import Popen, PIPE, STDOUT
 import os
 import sys

--- a/calendarserver/provision/test/test_root.py
+++ b/calendarserver/provision/test/test_root.py
@@ -180,7 +180,7 @@ class SACLTests(RootTests):
             raise AssertionError(
                 "RootResource.locateChild did not return an error"
             )
-        except HTTPError, e:
+        except HTTPError as e:
             self.assertEquals(e.response.code, 403)
 
     @inlineCallbacks
@@ -206,7 +206,7 @@ class SACLTests(RootTests):
             raise AssertionError(
                 "RootResource.locateChild did not return an error"
             )
-        except HTTPError, e:
+        except HTTPError as e:
             self.assertEquals(e.response.code, 401)
 
     @inlineCallbacks
@@ -239,7 +239,7 @@ class SACLTests(RootTests):
             raise AssertionError(
                 "RootResource.locateChild did not return an error"
             )
-        except HTTPError, e:
+        except HTTPError as e:
             self.assertEquals(e.response.code, 401)
 
     def test_DELETE(self):

--- a/calendarserver/push/applepush.py
+++ b/calendarserver/push/applepush.py
@@ -296,7 +296,7 @@ class APNProviderProtocol(Protocol):
                 command, status, identifier = struct.unpack("!BBI", message)
                 if command == self.COMMAND_ERROR:
                     yield fn(status, identifier)
-            except Exception, e:
+            except Exception as e:
                 self.log.warn(
                     "ProviderProtocol could not process error: {code} ({ex})",
                     code=message.encode("hex"), ex=e
@@ -705,7 +705,7 @@ class APNFeedbackProtocol(Protocol):
                     # the token itself
                     return
 
-            except Exception, e:
+            except Exception as e:
                 self.log.warn(
                     "FeedbackProtocol could not process message: ({ex})", ex=e
                 )

--- a/calendarserver/tap/caldav.py
+++ b/calendarserver/tap/caldav.py
@@ -405,7 +405,7 @@ class CalDAVOptions (Options):
                 self.waitForServerRoot()
             self.loadConfiguration()
             self.checkConfiguration()
-        except ConfigurationError, e:
+        except ConfigurationError as e:
             print("Invalid configuration:", e)
             sys.exit(1)
 
@@ -825,7 +825,7 @@ class CalDAVServiceMaker (object):
 
             try:
                 service = serviceMethod(options)
-            except ConfigurationError, e:
+            except ConfigurationError as e:
                 sys.stderr.write("Configuration error: {}\n".format(e))
                 sys.exit(1)
 
@@ -1111,7 +1111,7 @@ class CalDAVServiceMaker (object):
                 for fdAsStr in config.InheritSSLFDs:
                     try:
                         contextFactory = self.createContextFactory()
-                    except SSLError, e:
+                    except SSLError as e:
                         log.error(
                             "Unable to set up SSL context factory: {error}",
                             error=e
@@ -1140,7 +1140,7 @@ class CalDAVServiceMaker (object):
             else:
                 try:
                     contextFactory = self.createContextFactory()
-                except SSLError, e:
+                except SSLError as e:
                     self.log.error(
                         "Unable to set up SSL context factory: {error}",
                         error=e
@@ -1169,7 +1169,7 @@ class CalDAVServiceMaker (object):
 
                         try:
                             contextFactory = self.createContextFactory()
-                        except SSLError, e:
+                        except SSLError as e:
                             self.log.error(
                                 "Unable to set up SSL context factory: {error}"
                                 "Disabling SSL port: {port}",
@@ -1396,7 +1396,7 @@ class CalDAVServiceMaker (object):
                 stats = DashboardServer(logObserver, None)
                 stats.store = store
                 statsService = GroupOwnedUNIXServer(
-                    gid, config.Stats.UnixStatsSocket, stats, mode=0660
+                    gid, config.Stats.UnixStatsSocket, stats, mode=0o660
                 )
                 statsService.setName("unix-stats")
                 statsService.setServiceParent(result)
@@ -1766,7 +1766,7 @@ class CalDAVServiceMaker (object):
             )
         if config.ControlSocket:
             controlSocketService = GroupOwnedUNIXServer(
-                gid, config.ControlSocket, controlSocket, mode=0660
+                gid, config.ControlSocket, controlSocket, mode=0o660
             )
         else:
             controlSocketService = ControlPortTCPServer(
@@ -1865,7 +1865,7 @@ class CalDAVServiceMaker (object):
         if config.Stats.EnableUnixStatsSocket:
             stats = DashboardServer(logger.observer, cl if config.UseMetaFD else None)
             statsService = GroupOwnedUNIXServer(
-                gid, config.Stats.UnixStatsSocket, stats, mode=0660
+                gid, config.Stats.UnixStatsSocket, stats, mode=0o660
             )
             statsService.setName("unix-stats")
             statsService.setServiceParent(s)

--- a/calendarserver/tap/profiling.py
+++ b/calendarserver/tap/profiling.py
@@ -32,7 +32,7 @@ class CProfileCPURunner(CProfileRunner):
         try:
             import cProfile
             import pstats
-        except ImportError, e:
+        except ImportError as e:
             self._reportImportError("cProfile", e)
 
         p = cProfile.Profile(time.clock)

--- a/calendarserver/tap/test/test_caldav.py
+++ b/calendarserver/tap/test/test_caldav.py
@@ -249,7 +249,7 @@ class CalDAVOptionsTest(StoreTestCase):
         self.config.parseOptions(argv)
 
         self.assertEquals(self.config.parent["pidfile"], "/dev/null")
-        self.assertEquals(self.config.parent["umask"], 0077)
+        self.assertEquals(self.config.parent["umask"], 0o077)
 
     def test_specifyConfigFile(self):
         """
@@ -336,7 +336,7 @@ class SocketGroupOwnership(StoreTestCase):
             " least two unix groups."
             ))
         socketName = self.mktemp()
-        gous = GroupOwnedUNIXServer(alternateGroup, socketName, ServerFactory(), mode=0660)
+        gous = GroupOwnedUNIXServer(alternateGroup, socketName, ServerFactory(), mode=0o660)
         gous.privilegedStartService()
         self.addCleanup(gous.stopService)
         filestat = os.stat(socketName)
@@ -416,7 +416,7 @@ class ModesOnUNIXSocketsTests(CalDAVServiceMakerTestBase):
         for serviceName in [_CONTROL_SERVICE_NAME]:
             socketService = svc.getServiceNamed(serviceName)
             self.assertIsInstance(socketService, GroupOwnedUNIXServer)
-            m = socketService.kwargs.get("mode", 0666)
+            m = socketService.kwargs.get("mode", 0o666)
             self.assertEquals(
                 m, int("660", 8),
                 "Wrong mode on %s: %s" % (serviceName, oct(m))
@@ -425,7 +425,7 @@ class ModesOnUNIXSocketsTests(CalDAVServiceMakerTestBase):
         for serviceName in ["unix-stats"]:
             socketService = svc.getServiceNamed(serviceName)
             self.assertIsInstance(socketService, GroupOwnedUNIXServer)
-            m = socketService.kwargs.get("mode", 0666)
+            m = socketService.kwargs.get("mode", 0o666)
             self.assertEquals(
                 m, int("660", 8),
                 "Wrong mode on %s: %s" % (serviceName, oct(m))
@@ -1349,7 +1349,7 @@ class SystemIDsTests(StoreTestCase):
             return 45
 
         return type(getSystemIDs)(
-            getSystemIDs.func_code,  # @UndefinedVariable
+            getSystemIDs.__code__,  # @UndefinedVariable
             {
                 "getpwnam": _getpwnam,
                 "getgrnam": _getgrnam,

--- a/calendarserver/tap/util.py
+++ b/calendarserver/tap/util.py
@@ -18,6 +18,7 @@
 """
 Utilities for assembling the service and resource hierarchy.
 """
+from __future__ import print_function
 
 __all__ = [
     "FakeRequest",
@@ -525,7 +526,7 @@ def getRootResource(config, newStore, resources=None):
             try:
                 FilePath(directoryPath).remove()
                 log.info("Deleted: {path}", path=directoryPath)
-            except (OSError, IOError), e:
+            except (OSError, IOError) as e:
                 if e.errno != errno.ENOENT:
                     log.error("Could not delete: {path} : {error}", path=directoryPath, error=e)
 
@@ -977,7 +978,7 @@ class MemoryLimitService(Service, object):
                     pid = proc.pid
                     try:
                         memory = self._memoryForPID(pid, self._residentOnly)
-                    except Exception, e:
+                    except Exception as e:
                         log.error(
                             "Unable to determine memory usage of PID: {pid} ({err})",
                             pid=pid, err=e)
@@ -1017,7 +1018,7 @@ def checkDirectories(config):
             config.DataRoot,
             "Data root",
             access=os.W_OK,
-            create=(0750, config.UserName, config.GroupName),
+            create=(0o750, config.UserName, config.GroupName),
         )
     if config.DocumentRoot.startswith(config.DataRoot + os.sep):
         checkDirectory(
@@ -1025,14 +1026,14 @@ def checkDirectories(config):
             "Document root",
             # Don't require write access because one might not allow editing on /
             access=os.R_OK,
-            create=(0750, config.UserName, config.GroupName),
+            create=(0o750, config.UserName, config.GroupName),
         )
     if config.ConfigRoot.startswith(config.ServerRoot + os.sep):
         checkDirectory(
             config.ConfigRoot,
             "Config root",
             access=os.W_OK,
-            create=(0750, config.UserName, config.GroupName),
+            create=(0o750, config.UserName, config.GroupName),
         )
     if config.SocketFiles.Enabled:
         checkDirectory(
@@ -1050,13 +1051,13 @@ def checkDirectories(config):
         config.LogRoot,
         "Log root",
         access=os.W_OK,
-        create=(0750, config.UserName, config.GroupName),
+        create=(0o750, config.UserName, config.GroupName),
     )
     checkDirectory(
         config.RunRoot,
         "Run root",
         access=os.W_OK,
-        create=(0770, config.UserName, config.GroupName),
+        create=(0o770, config.UserName, config.GroupName),
     )
 
 
@@ -1549,7 +1550,7 @@ class AlertPoster(object):
                     stdout=PIPE,
                     stderr=PIPE,
                 ).communicate()
-            except Exception, e:
+            except Exception as e:
                 log.error(
                     "Could not post alert: {alertType} {args} ({error})",
                     alertType=alertType, args=args, error=e

--- a/calendarserver/tools/ampnotifications.py
+++ b/calendarserver/tools/ampnotifications.py
@@ -81,7 +81,7 @@ def main():
                 "server=",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     #

--- a/calendarserver/tools/anonymize.py
+++ b/calendarserver/tools/anonymize.py
@@ -77,7 +77,7 @@ def main():
                 "node=",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     #
@@ -282,7 +282,7 @@ def anonymizeRoot(directoryMap, sourceDirectory, destDirectory):
 def anonymizeData(directoryMap, data):
     try:
         pyobj = Calendar.parseText(data)
-    except Exception, e:
+    except Exception as e:
         print("Failed to parse (%s): %s" % (e, data))
         return None
 

--- a/calendarserver/tools/calverify.py
+++ b/calendarserver/tools/calverify.py
@@ -753,7 +753,7 @@ class CalVerifyService(WorkerService, object):
             self.results.setdefault("Fix remove", set()).add((home.name(), calendar.name(), objname,))
 
             returnValue(True)
-        except Exception, e:
+        except Exception as e:
             print("Failed to remove resource whilst fixing: %d\n%s" % (resid, e,))
             returnValue(False)
 
@@ -1038,7 +1038,7 @@ class BadDataService(CalVerifyService):
         for owner, resid, uid, calname, _ignore_md5, _ignore_organizer, _ignore_created, _ignore_modified in rows:
             try:
                 result, message = yield self.validCalendarData(resid, calname == "inbox")
-            except Exception, e:
+            except Exception as e:
                 result = False
                 message = "Exception for validCalendarData"
                 if self.options["verbose"]:
@@ -1147,7 +1147,7 @@ class BadDataService(CalVerifyService):
             if self.options["ical"]:
                 self.attendeesWithoutOrganizer(component, doFix=False)
 
-        except ValueError, e:
+        except ValueError as e:
             result = False
             message = str(e)
             if message.startswith(self.errorPrefix):
@@ -1293,7 +1293,7 @@ class BadDataService(CalVerifyService):
                 # Use _migrating to ignore possible overridden instance errors - we are either correcting or ignoring those
                 self.txn._migrating = True
                 component = yield calendarObj._setComponentInternal(component, internal_state=ComponentUpdateState.RAW)
-            except Exception, e:
+            except Exception as e:
                 print(e, component)
                 print(traceback.print_exc())
                 result = False
@@ -1943,7 +1943,7 @@ class SchedulingMismatchService(CalVerifyService):
 
             returnValue(True)
 
-        except Exception, e:
+        except Exception as e:
             print("Failed to fix resource: %d for attendee: %s\n%s" % (orgresid, attendee, e,))
             returnValue(False)
 
@@ -2888,7 +2888,7 @@ class MissingLocationService(CalVerifyService):
         # Write out fix, commit and get a new transaction
         try:
             yield calendarObj.setComponent(component)
-        except Exception, e:
+        except Exception as e:
             print(e, component)
             print(traceback.print_exc())
             result = False
@@ -3116,7 +3116,7 @@ class UpgradeDataService(CalVerifyService):
                         yield calendarObj.component(doUpdate=True)
 
                 result = True
-            except Exception, e:
+            except Exception as e:
                 result = False
                 message = "Exception when reading resource"
                 if self.options["verbose"]:
@@ -3191,12 +3191,12 @@ def main(argv=sys.argv, stderr=sys.stderr, reactor=None):
     options = CalVerifyOptions()
     try:
         options.parseOptions(argv[1:])
-    except usage.UsageError, e:
+    except usage.UsageError as e:
         printusage(e)
 
     try:
         output = options.openOutput()
-    except IOError, e:
+    except IOError as e:
         stderr.write("Unable to open output file for writing: %s\n" % (e))
         sys.exit(1)
 

--- a/calendarserver/tools/checkdatabaseschema.py
+++ b/calendarserver/tools/checkdatabaseschema.py
@@ -94,7 +94,7 @@ def execSQL(title, stmt, verbose=False):
         out = subprocess.check_output(cmdArgs, stderr=subprocess.STDOUT)
         if verbose:
             print(out)
-    except subprocess.CalledProcessError, e:
+    except subprocess.CalledProcessError as e:
         if verbose:
             print(e.output)
         raise CheckSchemaError(
@@ -119,7 +119,7 @@ def getSchemaVersion(verbose=False):
 
     try:
         version = int(out[0][0])
-    except ValueError, e:
+    except ValueError as e:
         raise CheckSchemaError(
             "Failed to parse schema version: %s" % (e,)
         )
@@ -273,7 +273,7 @@ def main():
                 "verbose",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     verbose = False
@@ -310,7 +310,7 @@ def main():
     # Retrieve the db_version number of the installed schema
     try:
         db_version = getSchemaVersion(verbose=verbose)
-    except CheckSchemaError, e:
+    except CheckSchemaError as e:
         db_version = 0
 
     # Retrieve the version number from the schema file

--- a/calendarserver/tools/cmdline.py
+++ b/calendarserver/tools/cmdline.py
@@ -129,7 +129,7 @@ def utilityMain(
         if loadTimezones:
             TimezoneCache.create()
 
-    except (ConfigurationError, OSError), e:
+    except (ConfigurationError, OSError) as e:
         sys.stderr.write("Error: %s\n" % (e,))
         return
 
@@ -145,7 +145,7 @@ class WorkerService(Service):
         try:
             from twistedcaldav.config import config
             rootResource = getRootResource(config, self.store)
-        except OSError, e:
+        except OSError as e:
             if e.errno == ENOENT:
                 # Trying to re-write resources.xml but its parent directory does
                 # not exist.  The server's never been started, so we're missing
@@ -174,9 +174,9 @@ class WorkerService(Service):
                 yield self.doWork()
             else:
                 yield self.doWorkWithoutStore()
-        except ConfigurationError, ce:
+        except ConfigurationError as ce:
             sys.stderr.write("Error: %s\n" % (str(ce),))
-        except Exception, e:
+        except Exception as e:
             sys.stderr.write("Error: %s\n" % (e,))
             raise
         finally:

--- a/calendarserver/tools/config.py
+++ b/calendarserver/tools/config.py
@@ -155,7 +155,7 @@ def main():
                 "logging=",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     configFileName = DEFAULT_CONFIG_FILE
@@ -193,7 +193,7 @@ def main():
 
     try:
         config.load(configFileName)
-    except ConfigurationError, e:
+    except ConfigurationError as e:
         sys.stdout.write("%s\n" % (e,))
         sys.exit(1)
 
@@ -335,7 +335,7 @@ def processArgs(writable, args, restart=True):
         try:
             plist = readPlistFromString(rawInput)
             # Note: values in plist will already be unicode
-        except xml.parsers.expat.ExpatError, e:  # @UndefinedVariable
+        except xml.parsers.expat.ExpatError as e:  # @UndefinedVariable
             respondWithError(str(e))
             return
 
@@ -396,7 +396,7 @@ class Runner(object):
                 else:
                     respondWithError("Unknown command '%s'" % (commandName,))
 
-        except Exception, e:
+        except Exception as e:
             respondWithError("Command failed: '%s'" % (str(e),))
             raise
 
@@ -434,7 +434,7 @@ class Runner(object):
                 writable.set(setKeyPath(ConfigDict(), keyPath, value))
         try:
             writable.save(restart=False)
-        except Exception, e:
+        except Exception as e:
             respond(command, {"error": str(e)})
         else:
             config.reload()

--- a/calendarserver/tools/dashboard.py
+++ b/calendarserver/tools/dashboard.py
@@ -18,6 +18,7 @@
 A curses (or plain text) based dashboard for viewing various aspects of the
 server as exposed by the L{DashboardProtocol} stats socket.
 """
+from __future__ import print_function
 
 import argparse
 import collections

--- a/calendarserver/tools/dashcollect.py
+++ b/calendarserver/tools/dashcollect.py
@@ -43,6 +43,7 @@ sample is shown below:
     }
 }
 """
+from __future__ import print_function
 
 from argparse import HelpFormatter, SUPPRESS, OPTIONAL, ZERO_OR_MORE, \
     ArgumentParser

--- a/calendarserver/tools/dashtime.py
+++ b/calendarserver/tools/dashtime.py
@@ -17,6 +17,7 @@
 """
 Tool that extracts time series data from a dashcollect log.
 """
+from __future__ import print_function
 
 from argparse import SUPPRESS, OPTIONAL, ZERO_OR_MORE, HelpFormatter, \
     ArgumentParser

--- a/calendarserver/tools/dashview.py
+++ b/calendarserver/tools/dashview.py
@@ -19,6 +19,7 @@
 A curses (or plain text) based dashboard for viewing various aspects of the
 server as exposed by the L{DashboardProtocol} stats socket.
 """
+from __future__ import print_function
 
 from argparse import HelpFormatter, SUPPRESS, OPTIONAL, ZERO_OR_MORE, \
     ArgumentParser

--- a/calendarserver/tools/dbinspect.py
+++ b/calendarserver/tools/dbinspect.py
@@ -888,7 +888,7 @@ class DBInspectService(WorkerService, object):
         try:
             yield cmd().doIt(txn)
             yield txn.commit()
-        except Exception, e:
+        except Exception as e:
             traceback.print_exc()
             print("Command '%s' failed because of: %s" % (cmd.name(), e,))
             yield txn.abort()

--- a/calendarserver/tools/delegatesmigration.py
+++ b/calendarserver/tools/delegatesmigration.py
@@ -97,7 +97,7 @@ def main():
                 "dbtype=",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     #
@@ -210,7 +210,7 @@ def copyAssignments(assignments, pod, directory, store):
                     recordTypes=delegatorRecordTypes
                 )
                 delegatorRecord = uniqueResult(delegatorRecords)
-            except Exception, e:
+            except Exception as e:
                 print("Failed to look up record for {}: {}".format(delegatorUID, str(e)))
                 continue
 
@@ -240,7 +240,7 @@ def copyAssignments(assignments, pod, directory, store):
                 )
                 delegateRecord = uniqueResult(delegateRecords)
 
-            except Exception, e:
+            except Exception as e:
                 print("Failed to look up record for {}: {}".format(delegateUID, str(e)))
                 continue
 

--- a/calendarserver/tools/diagnose.py
+++ b/calendarserver/tools/diagnose.py
@@ -65,7 +65,7 @@ def main():
                 "phantom",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     for opt, arg in optargs:

--- a/calendarserver/tools/dkimtool.py
+++ b/calendarserver/tools/dkimtool.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 ##
 
+from __future__ import print_function
 import os
 import sys
 from Crypto.PublicKey import RSA
@@ -52,7 +53,7 @@ def _doKeyGeneration(options):
             f.write(output)
     else:
         if lineBreak:
-            print
+            print()
         print(output)
         lineBreak = True
 
@@ -60,7 +61,7 @@ def _doKeyGeneration(options):
         output = "".join(output.splitlines()[1:-1])
         txt = "v=DKIM1; p=%s" % (output,)
         if lineBreak:
-            print
+            print()
         print(txt)
 
 
@@ -131,7 +132,7 @@ def _doVerify(options):
 
     try:
         yield dkim.verify()
-    except DKIMVerificationError, e:
+    except DKIMVerificationError as e:
         print("Verification Failed: %s" % (e,))
     else:
         print("Verification Succeeded")
@@ -279,7 +280,7 @@ def _runInReactor(fn, options):
 
     try:
         yield fn(options)
-    except Exception, e:
+    except Exception as e:
         print(e)
     finally:
         reactor.stop()

--- a/calendarserver/tools/export.py
+++ b/calendarserver/tools/export.py
@@ -495,7 +495,7 @@ def main(argv=sys.argv, stderr=sys.stderr, reactor=None):
     options = ExportOptions()
     try:
         options.parseOptions(argv[1:])
-    except UsageError, e:
+    except UsageError as e:
         usage(e)
 
     if options.outputDirectoryName:
@@ -503,7 +503,7 @@ def main(argv=sys.argv, stderr=sys.stderr, reactor=None):
     else:
         try:
             output = options.openOutput()
-        except IOError, e:
+        except IOError as e:
             stderr.write(
                 "Unable to open output file for writing: %s\n" % (e)
             )

--- a/calendarserver/tools/gateway.py
+++ b/calendarserver/tools/gateway.py
@@ -128,7 +128,7 @@ def main():
                 "config=",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     #
@@ -156,7 +156,7 @@ def main():
     rawInput = sys.stdin.read()
     try:
         plist = readPlistFromString(rawInput)
-    except xml.parsers.expat.ExpatError, e:  # @UndefinedVariable
+    except xml.parsers.expat.ExpatError as e:  # @UndefinedVariable
         respondWithError(str(e))
         return
 
@@ -214,7 +214,7 @@ class Runner(object):
                 else:
                     self.respondWithError("Unknown command '%s'" % (commandName,))
 
-        except Exception, e:
+        except Exception as e:
             self.respondWithError("Command failed: '%s'" % (str(e),))
             raise
 
@@ -461,7 +461,7 @@ class Runner(object):
                 writable.set(setKeyPath(ConfigDict(), keyPath, value))
         try:
             writable.save(restart=False)
-        except Exception, e:
+        except Exception as e:
             self.respond(command, {"error": str(e)})
         else:
             self.command_readConfig(command)

--- a/calendarserver/tools/icalsplit.py
+++ b/calendarserver/tools/icalsplit.py
@@ -89,7 +89,7 @@ def main():
                 "help",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     for opt, _ignore_arg in optargs:

--- a/calendarserver/tools/importer.py
+++ b/calendarserver/tools/importer.py
@@ -235,7 +235,7 @@ def importCollectionComponent(store, component):
                 # That event is already in the home
                 print("Skipping since UID already exists: {}".format(uid))
 
-            except Exception, e:
+            except Exception as e:
                 print(
                     "Failed to import due to: {error}\n{comp}".format(
                         error=e,
@@ -357,7 +357,7 @@ class ImporterService(WorkerService, object):
             else:
                 try:
                     input = self.options.openInput()
-                except IOError, e:
+                except IOError as e:
                     sys.stderr.write(
                         "Unable to open input file for reading: %s\n" % (e)
                     )
@@ -396,7 +396,7 @@ def main(argv=sys.argv, reactor=None):
     options = ImportOptions()
     try:
         options.parseOptions(argv[1:])
-    except UsageError, e:
+    except UsageError as e:
         usage(e)
 
     def makeService(store):

--- a/calendarserver/tools/managetimezones.py
+++ b/calendarserver/tools/managetimezones.py
@@ -223,7 +223,7 @@ def _runInReactor(tzdb):
         print("New:           {}".format(new,))
         print("Changed:       {}".format(changed,))
         print("Current total: {}".format(len(tzdb.timezones),))
-    except Exception, e:
+    except Exception as e:
         print("Could not sync with server: {}".format(str(e),))
     finally:
         reactor.stop()
@@ -362,7 +362,7 @@ def main():
         usage("A configuration file must be specified")
     try:
         loadConfig(configFileName)
-    except ConfigurationError, e:
+    except ConfigurationError as e:
         sys.stdout.write("{}\n".format(e,))
         sys.exit(1)
 

--- a/calendarserver/tools/manhole_utils.py
+++ b/calendarserver/tools/manhole_utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 ##
 # Copyright (c) 2017 Apple Inc. All rights reserved.
 #

--- a/calendarserver/tools/migrate.py
+++ b/calendarserver/tools/migrate.py
@@ -64,7 +64,7 @@ def main():
                 "help",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     configFileName = None
@@ -81,7 +81,7 @@ def main():
 
     try:
         config = loadConfig(configFileName)
-    except ConfigurationError, e:
+    except ConfigurationError as e:
         sys.stdout.write("%s\n" % (e,))
         sys.exit(1)
 

--- a/calendarserver/tools/migrate_verify.py
+++ b/calendarserver/tools/migrate_verify.py
@@ -360,7 +360,7 @@ def main(argv=sys.argv, stderr=sys.stderr, reactor=None):
     options.parseOptions(argv[1:])
     try:
         output = options.openOutput()
-    except IOError, e:
+    except IOError as e:
         stderr.write("Unable to open output file for writing: %s\n" % (e))
         sys.exit(1)
 

--- a/calendarserver/tools/notifications.py
+++ b/calendarserver/tools/notifications.py
@@ -86,7 +86,7 @@ def main():
                 "verbose",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     admin = None
@@ -126,7 +126,7 @@ def main():
         # No host specified, so try loading config to look up settings
         try:
             loadConfig(configFileName)
-        except ConfigurationError, e:
+        except ConfigurationError as e:
             print("Error in configuration: %s" % (e,))
             sys.exit(1)
 
@@ -280,7 +280,7 @@ class PubSubClientFactory(xmlstream.XmlStreamFactory):
         try:
             yield iq.send(to=self.service)
             print("OK")
-        except Exception, e:
+        except Exception as e:
             print("Subscription failure: %s %s" % (node, e))
 
     @inlineCallbacks
@@ -296,7 +296,7 @@ class PubSubClientFactory(xmlstream.XmlStreamFactory):
         try:
             yield iq.send(to=self.service)
             print("OK")
-        except Exception, e:
+        except Exception as e:
             print("Unsubscription failure: %s %s" % (node, e))
 
     @inlineCallbacks
@@ -308,7 +308,7 @@ class PubSubClientFactory(xmlstream.XmlStreamFactory):
         print("Requesting list of subscriptions")
         try:
             yield iq.send(to=self.service)
-        except Exception, e:
+        except Exception as e:
             print("Subscription list failure: %s" % (e,))
 
     def rawDataIn(self, buf):
@@ -382,7 +382,7 @@ class PushMonitorService(Service):
                 print("No nodes to monitor")
                 reactor.stop()
 
-        except Exception, e:
+        except Exception as e:
             print("Error:", e)
             reactor.stop()
 
@@ -442,12 +442,12 @@ class PushMonitorService(Service):
                                     if displayName:
                                         name = displayName
 
-            except Exception, e:
+            except Exception as e:
                 print("Unable to parse principal details", e)
                 print(responseBody)
                 raise
 
-        except Exception, e:
+        except Exception as e:
             print("Unable to look up principal details", e)
             raise
 
@@ -498,12 +498,12 @@ class PushMonitorService(Service):
                                             if href:
                                                 proxies.add(href)
 
-            except Exception, e:
+            except Exception as e:
                 print("Unable to parse proxy information", e)
                 print(responseBody)
                 raise
 
-        except Exception, e:
+        except Exception as e:
             print("Unable to look up who %s is a proxy for" % (self.username,))
             raise
 
@@ -588,12 +588,12 @@ class PushMonitorService(Service):
                     if key and key not in nodes:
                         nodes[key] = (href.text, name, kind)
 
-            except Exception, e:
+            except Exception as e:
                 print("Unable to parse push information", e)
                 print(responseBody)
                 raise
 
-        except Exception, e:
+        except Exception as e:
             print("Unable to look up push information for %s" % (self.username,))
             raise
 

--- a/calendarserver/tools/obliterate.py
+++ b/calendarserver/tools/obliterate.py
@@ -556,7 +556,7 @@ def main(argv=sys.argv, stderr=sys.stderr, reactor=None):
     options.parseOptions(argv[1:])
     try:
         output = options.openOutput()
-    except IOError, e:
+    except IOError as e:
         stderr.write("Unable to open output file for writing: %s\n" % (e))
         sys.exit(1)
 

--- a/calendarserver/tools/pod_migration.py
+++ b/calendarserver/tools/pod_migration.py
@@ -263,7 +263,7 @@ def main(argv=sys.argv, stderr=sys.stderr, reactor=None):
 
     try:
         output = options.openOutput()
-    except IOError, e:
+    except IOError as e:
         stderr.write("Unable to open output file for writing: %s\n" % (e))
         sys.exit(1)
 

--- a/calendarserver/tools/principals.py
+++ b/calendarserver/tools/principals.py
@@ -187,7 +187,7 @@ def main():
                 "verbose",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     #
@@ -281,7 +281,7 @@ def main():
                     raise ValueError("Unknown auto-schedule mode: {mode}".format(
                         mode=arg))
                 autoScheduleMode = allowedAutoScheduleModes[arg]
-            except ValueError, e:
+            except ValueError as e:
                 abort(e)
 
             principalActions.append((action_setAutoScheduleMode, autoScheduleMode))
@@ -349,13 +349,13 @@ def main():
                     "locations", "resources", "addresses", "users", "groups"
                 ]
             )
-        except ValueError, e:
+        except ValueError as e:
             print(e)
             return
 
         try:
             fullName, shortName, uid = parseCreationArgs(args)
-        except ValueError, e:
+        except ValueError as e:
             print(e)
             return
 
@@ -378,7 +378,7 @@ def main():
                 listPrincipals,
                 ["users", "groups", "locations", "resources", "addresses"]
             )
-        except ValueError, e:
+        except ValueError as e:
             print(e)
             return
 
@@ -423,7 +423,7 @@ def runListPrincipals(service, store, listPrincipals):
             printRecordList(records)
         else:
             print("No records of type %s" % (listPrincipals,))
-    except InvalidDirectoryRecordError, e:
+    except InvalidDirectoryRecordError as e:
         usage(e)
     returnValue(None)
 

--- a/calendarserver/tools/purge.py
+++ b/calendarserver/tools/purge.py
@@ -318,7 +318,7 @@ class PurgeOldEventsService(WorkerService):
                     "debug",
                 ],
             )
-        except GetoptError, e:
+        except GetoptError as e:
             cls.usage(e)
 
         #
@@ -339,14 +339,14 @@ class PurgeOldEventsService(WorkerService):
             elif opt in ("-d", "--days"):
                 try:
                     days = int(arg)
-                except ValueError, e:
+                except ValueError as e:
                     print("Invalid value for --days: %s" % (arg,))
                     cls.usage(e)
 
             elif opt in ("-b", "--batch"):
                 try:
                     batchSize = int(arg)
-                except ValueError, e:
+                except ValueError as e:
                     print("Invalid value for --batch: %s" % (arg,))
                     cls.usage(e)
 
@@ -744,7 +744,7 @@ class PurgeAttachmentsService(WorkerService):
                     "debug",
                 ],
             )
-        except GetoptError, e:
+        except GetoptError as e:
             cls.usage(e)
 
         #
@@ -768,14 +768,14 @@ class PurgeAttachmentsService(WorkerService):
             elif opt in ("-d", "--days"):
                 try:
                     days = int(arg)
-                except ValueError, e:
+                except ValueError as e:
                     print("Invalid value for --days: %s" % (arg,))
                     cls.usage(e)
 
             elif opt in ("-b", "--batch"):
                 try:
                     batchSize = int(arg)
-                except ValueError, e:
+                except ValueError as e:
                     print("Invalid value for --batch: %s" % (arg,))
                     cls.usage(e)
 
@@ -1088,7 +1088,7 @@ class PurgePrincipalService(WorkerService):
                     "debug",
                 ],
             )
-        except GetoptError, e:
+        except GetoptError as e:
             cls.usage(e)
 
         #
@@ -1290,7 +1290,7 @@ class PurgePrincipalService(WorkerService):
                         try:
                             yield childResource.purge(implicitly=doScheduling)
                             incrementCount = True
-                        except Exception, e:
+                        except Exception as e:
                             print("Exception deleting %s: %s" % (uri, str(e)))
                             retry = True
 
@@ -1300,7 +1300,7 @@ class PurgePrincipalService(WorkerService):
                             try:
                                 yield childResource.purge(implicitly=False)
                                 incrementCount = True
-                            except Exception, e:
+                            except Exception as e:
                                 print("Still couldn't delete %s even with scheduling turned off: %s" % (uri, str(e)))
 
                     if incrementCount:
@@ -1309,7 +1309,7 @@ class PurgePrincipalService(WorkerService):
                     # Commit
                     yield txn.commit()
 
-                except Exception, e:
+                except Exception as e:
                     # Abort
                     yield txn.abort()
                     raise e
@@ -1370,7 +1370,7 @@ class PurgePrincipalService(WorkerService):
             # Commit
             yield txn.commit()
 
-        except Exception, e:
+        except Exception as e:
             # Abort
             yield txn.abort()
             raise e
@@ -1421,7 +1421,7 @@ class PurgePrincipalService(WorkerService):
             # Commit
             yield txn.commit()
 
-        except Exception, e:
+        except Exception as e:
             # Abort
             yield txn.abort()
             raise e

--- a/calendarserver/tools/push.py
+++ b/calendarserver/tools/push.py
@@ -57,7 +57,7 @@ def main():
 @inlineCallbacks
 def displayAPNSubscriptions(store, directory, root, users):
     for user in users:
-        print
+        print()
         record = yield directory.recordWithShortName(RecordType.user, user)
         if record is not None:
             print("User %s (%s)..." % (user, record.uid))
@@ -69,7 +69,7 @@ def displayAPNSubscriptions(store, directory, root, users):
                 for apnrecord in subscriptions:
                     byKey.setdefault(apnrecord.resourceKey, []).append(apnrecord)
                 for key, apnsrecords in byKey.iteritems():
-                    print
+                    print()
                     protocol, _ignore_host, path = key.strip("/").split("/", 2)
                     resource = {
                         "CalDAV": "calendar",

--- a/calendarserver/tools/resources.py
+++ b/calendarserver/tools/resources.py
@@ -78,7 +78,7 @@ def main():
                 "config=",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     #

--- a/calendarserver/tools/shell/cmd.py
+++ b/calendarserver/tools/shell/cmd.py
@@ -398,7 +398,7 @@ class Commands(CommandsBase):
         from twisted.python.log import startLogging
         try:
             f = open(fileName, "w")
-        except (IOError, OSError), e:
+        except (IOError, OSError) as e:
             self.terminal.write("Unable to open file %s: %s\n" % (fileName, e))
             return
 

--- a/calendarserver/tools/shell/terminal.py
+++ b/calendarserver/tools/shell/terminal.py
@@ -290,7 +290,7 @@ class ShellProtocol(ReceiveLineProtocol):
                 return
             try:
                 completions = tuple((yield m(tokens)))
-            except Exception, e:
+            except Exception as e:
                 self.handleFailure(Failure(e))
                 return
             log.info("COMPLETIONS: {comp}", comp=completions)
@@ -299,7 +299,7 @@ class ShellProtocol(ReceiveLineProtocol):
             completions = tuple(self.commands.complete_commands(cmd))
 
         if len(completions) == 1:
-            for c in completions.__iter__().next():
+            for c in next(completions.__iter__()):
                 self.characterReceived(c, True)
 
             # FIXME: Add a space only if we know we've fully completed the term.
@@ -405,7 +405,7 @@ def main(argv=sys.argv, stderr=sys.stderr, reactor=None):
     options = ShellOptions()
     try:
         options.parseOptions(argv[1:])
-    except UsageError, e:
+    except UsageError as e:
         usage(e)
 
     def makeService(store):

--- a/calendarserver/tools/shell/vfs.py
+++ b/calendarserver/tools/shell/vfs.py
@@ -114,7 +114,7 @@ class ListEntry(object):
     def toFields(self):
         try:
             return tuple(self.fields[fieldName] for fieldName in self.fieldNames)
-        except KeyError, e:
+        except KeyError as e:
             raise AssertionError(
                 "Field %s is not in %r, defined by %s"
                 % (e, self.fields.keys(), self.parent.__name__)
@@ -653,7 +653,7 @@ class CalendarObject(File):
                 self.summary = mainComponent.propertyValue("SUMMARY")
                 self.mainComponent = mainComponent
 
-            except InvalidICalendarDataError, e:
+            except InvalidICalendarDataError as e:
                 log.error("{path}: {ex}", path=self.path, ex=e)
 
                 self.componentType = "?"

--- a/calendarserver/tools/tables.py
+++ b/calendarserver/tools/tables.py
@@ -277,7 +277,7 @@ class Table(object):
             colData = ""
 
         columnFormat = format[column] if format and column < len(format) else Table.ColumnFormat()
-        if type(colData) in types.StringTypes:
+        if type(colData) in (str,):
             text = colData
         else:
             text = columnFormat.format % colData

--- a/calendarserver/tools/test/test_gateway.py
+++ b/calendarserver/tools/test/test_gateway.py
@@ -173,7 +173,7 @@ class RunCommandTestCase(TestCase):
             try:
                 plist = readPlistFromString(output)
                 returnValue(plist)
-            except xml.parsers.expat.ExpatError, e:  # @UndefinedVariable
+            except xml.parsers.expat.ExpatError as e:  # @UndefinedVariable
                 print("Error (%s) parsing (%s)" % (e, output))
                 raise
         else:

--- a/calendarserver/tools/upgrade.py
+++ b/calendarserver/tools/upgrade.py
@@ -19,6 +19,7 @@
 """
 This tool allows any necessary upgrade to complete, then exits.
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -208,12 +209,12 @@ def main(argv=sys.argv, stderr=sys.stderr, reactor=None):
     options = UpgradeOptions()
     try:
         options.parseOptions(argv[1:])
-    except UsageError, e:
+    except UsageError as e:
         usage(e)
 
     try:
         output = options.openOutput()
-    except IOError, e:
+    except IOError as e:
         stderr.write("Unable to open output file for writing: %s\n" % (e))
         sys.exit(1)
 

--- a/calendarserver/tools/util.py
+++ b/calendarserver/tools/util.py
@@ -17,6 +17,7 @@
 """
 Utility functionality shared between calendarserver tools.
 """
+from __future__ import print_function
 
 __all__ = [
     "loadConfig",
@@ -74,7 +75,7 @@ def loadConfig(configFileName):
     return config
 
 
-class UsageError (StandardError):
+class UsageError (Exception):
     pass
 
 
@@ -167,7 +168,7 @@ def checkDirectory(dirpath, description, access=None, create=None, wait=False):
                                          % (description, dirpath))
             try:
                 os.mkdir(dirpath)
-            except (OSError, IOError), e:
+            except (OSError, IOError) as e:
                 print("Could not create %s: %s" % (dirpath, e))
                 raise ConfigurationError(
                     "%s does not exist and cannot be created: %s"
@@ -187,7 +188,7 @@ def checkDirectory(dirpath, description, access=None, create=None, wait=False):
             try:
                 os.chmod(dirpath, mode)
                 os.chown(dirpath, uid, gid)
-            except (OSError, IOError), e:
+            except (OSError, IOError) as e:
                 print("Unable to change mode/owner of %s: %s" % (dirpath, e))
 
             print("Created directory: %s" % (dirpath,))

--- a/calendarserver/tools/validcalendardata.py
+++ b/calendarserver/tools/validcalendardata.py
@@ -164,7 +164,7 @@ class ValidService(WorkerService, object):
             if fixed:
                 print("Calendar data had fixable problems:\n  %s" % ("\n  ".join(fixed),))
 
-        except ValueError, e:
+        except ValueError as e:
             result = False
             message = str(e)
             if message.startswith(errorPrefix):
@@ -187,7 +187,7 @@ class ValidService(WorkerService, object):
             component.validCalendarData(doFix=False, validateRecurrences=True)
             component.validCalendarForCalDAV(methodAllowed=True)
             component.validOrganizerForScheduling(doFix=False)
-        except ValueError, e:
+        except ValueError as e:
             result = False
             message = str(e)
             if message.startswith(errorPrefix):
@@ -208,12 +208,12 @@ def main(argv=sys.argv, stderr=sys.stderr, reactor=None):
     options.parseOptions(argv[1:])
     try:
         output = options.openOutput()
-    except IOError, e:
+    except IOError as e:
         stderr.write("Unable to open output file for writing: %s\n" % (e))
         sys.exit(1)
     try:
         input = options.openInput()
-    except IOError, e:
+    except IOError as e:
         stderr.write("Unable to open input file for reading: %s\n" % (e))
         sys.exit(1)
 

--- a/calendarserver/tools/wiki.py
+++ b/calendarserver/tools/wiki.py
@@ -74,7 +74,7 @@ def main():
                 "config=",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     #

--- a/calendarserver/webcal/resource.py
+++ b/calendarserver/webcal/resource.py
@@ -169,7 +169,7 @@ class WebCalendarResource (ReadOnlyResourceMixIn, DAVFile):
                 "tzid": tzid,
                 "principalURL": authenticatedPrincipalURL,
             }
-        except IOError, e:
+        except IOError as e:
             self.log.error("Unable to obtain WebCalendar template: %s" % (e,))
             return responsecode.NOT_FOUND
 

--- a/contrib/od/setup_directory.py
+++ b/contrib/od/setup_directory.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 ##
 from __future__ import print_function
+from __future__ import absolute_import
 
 import os
 import sys
-import odframework
-import dsattributes
+from . import odframework
+from . import dsattributes
 from getopt import getopt, GetoptError
 
 # TODO: Nested groups
@@ -300,7 +301,7 @@ def main():
 
     try:
         (optargs, args) = getopt(sys.argv[1:], "h", ["help"])
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     for opt, _ignore_arg in optargs:
@@ -368,7 +369,7 @@ def main():
                         print("Failed to set password for %s: %s" % (recordName, error))
                     else:
                         print("Successfully set password for %s" % (recordName,))
-                except ODError, e:
+                except ODError as e:
                     print("Failed to create user %s: %s" % (recordName, e))
             else:
                 print("User %s already exists" % (recordName,))
@@ -384,12 +385,12 @@ def main():
                 try:
                     record = createRecord(node, dsattributes.kDSStdRecordTypeGroups, recordName, attrs)
                     print("Successfully created group %s" % (recordName,))
-                except ODError, e:
+                except ODError as e:
                     print("Failed to create group %s: %s" % (recordName, e))
             else:
                 print("Group %s already exists" % (recordName,))
 
-        print
+        print()
 
     # Populate SACL groups
     node, error = odframework.ODNode.nodeWithSession_name_error_(session, saclGroupNodeName, None)

--- a/contrib/od/test/test_live.py
+++ b/contrib/od/test/test_live.py
@@ -59,7 +59,7 @@ if moduleImported:
                 result = yield func(self)
                 returnValue(result)
             else:
-                print("OD not populated, skipping {}".format(func.func_name))
+                print("OD not populated, skipping {}".format(func.__name__))
         return checkThenRun
 
     class LiveOpenDirectoryServiceTestCase(unittest.TestCase):

--- a/contrib/performance/_event_change.py
+++ b/contrib/performance/_event_change.py
@@ -17,6 +17,7 @@
 """
 Benchmark a server's handling of event summary changes.
 """
+from __future__ import absolute_import
 
 from itertools import count
 
@@ -28,12 +29,12 @@ from twisted.web.client import Agent
 from twisted.web.http_headers import Headers
 from twisted.web.http import NO_CONTENT
 
-from httpauth import AuthHandlerAgent
-from httpclient import StringProducer
+from .httpauth import AuthHandlerAgent
+from .httpclient import StringProducer
 
-from benchlib import initialize, sample
+from .benchlib import initialize, sample
 
-from _event_create import makeEvent
+from ._event_create import makeEvent
 
 
 @inlineCallbacks

--- a/contrib/performance/_event_create.py
+++ b/contrib/performance/_event_create.py
@@ -17,6 +17,7 @@
 """
 Various helpers for event-creation benchmarks.
 """
+from __future__ import absolute_import
 
 from uuid import uuid4
 from urllib2 import HTTPDigestAuthHandler
@@ -28,9 +29,9 @@ from twisted.web.http import CREATED
 from twisted.web.client import Agent
 from twisted.internet import reactor
 
-from httpauth import AuthHandlerAgent
-from benchlib import initialize, sample
-from httpclient import StringProducer
+from .httpauth import AuthHandlerAgent
+from .benchlib import initialize, sample
+from .httpclient import StringProducer
 
 
 # XXX Represent these as pycalendar objects?  Would make it easier to add more vevents.

--- a/contrib/performance/benchlib.py
+++ b/contrib/performance/benchlib.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 ##
 from __future__ import print_function
+from __future__ import absolute_import
 
 import pickle
 from time import time
@@ -24,8 +25,8 @@ from twisted.web.http_headers import Headers
 from twisted.python.log import msg
 from twisted.web.http import NO_CONTENT, NOT_FOUND
 
-from stats import Duration
-from httpclient import StringProducer, readBody
+from .stats import Duration
+from .httpclient import StringProducer, readBody
 
 
 class CalDAVAccount(object):
@@ -161,7 +162,7 @@ def sample(dtrace, sampleTime, agent, paramgen, responseCode, concurrency=1):
     while requests:
         try:
             _ignore_result, index = yield DeferredList(requests, fireOnOneCallback=True, fireOnOneErrback=True)
-        except FirstError, e:
+        except FirstError as e:
             e.subFailure.raiseException()
 
         # Get rid of the completed Deferred

--- a/contrib/performance/benchmark.py
+++ b/contrib/performance/benchmark.py
@@ -422,7 +422,7 @@ def main():
     options = BenchmarkOptions()
     try:
         options.parseOptions(sys.argv[1:])
-    except UsageError, e:
+    except UsageError as e:
         print(e)
         return 1
 

--- a/contrib/performance/benchmarks/event_move.py
+++ b/contrib/performance/benchmarks/event_move.py
@@ -70,8 +70,8 @@ def measure(host, port, dtrace, attendeeCount, samples):
     dest = cycle([barURI, fooURI])
 
     params = (
-        ('MOVE', source.next(),
-         Headers({"destination": [dest.next()], "overwrite": ["F"]}))
+        ('MOVE', next(source),
+         Headers({"destination": [next(dest)], "overwrite": ["F"]}))
         for i in count(1))
 
     samples = yield sample(dtrace, samples, agent, params.next, CREATED)

--- a/contrib/performance/compare.py
+++ b/contrib/performance/compare.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 ##
 from __future__ import print_function
+from __future__ import absolute_import
 
 import sys
 
-import stats
+from . import stats
 
-from benchlib import load_stats
+from .benchlib import load_stats
 
 try:
     from scipy.stats import ttest_1samp

--- a/contrib/performance/display-calendar-events.py
+++ b/contrib/performance/display-calendar-events.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 ##
 from __future__ import print_function
+from __future__ import absolute_import
 
-import eventkitframework as EventKit
+from . import eventkitframework as EventKit
 from Cocoa import NSDate
 
 store = EventKit.EKEventStore.alloc().init()

--- a/contrib/performance/graph.py
+++ b/contrib/performance/graph.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ##
 # Copyright (c) 2010-2017 Apple Inc. All rights reserved.
 #
@@ -19,7 +20,7 @@ import sys
 from matplotlib import pyplot
 import numpy
 
-from benchlib import load_stats
+from .benchlib import load_stats
 
 
 def main():

--- a/contrib/performance/jobqueue/loadtest.py
+++ b/contrib/performance/jobqueue/loadtest.py
@@ -16,6 +16,7 @@
 ##
 
 
+from __future__ import print_function
 from caldavclientlibrary.client.httpshandler import SmartHTTPConnection
 from multiprocessing import Process, Value
 import getopt
@@ -81,7 +82,7 @@ def httploop(ctr, config, complete):
     iter = itertools.cycle(server_details)
     while not complete.value:
 
-        server = iter.next()
+        server = next(iter)
         count += 1
 
         http = SmartHTTPConnection(server.host, server.port, server.use_ssl, False)
@@ -239,14 +240,14 @@ if __name__ == '__main__':
     print("  Effective request rate: {} req/sec".format(effective_rate))
     print("  Jobs per request: {}".format(config["jobs"]))
     print("  Effective job rate: {} jobs/sec".format(effective_rate * config["jobs"]))
-    print("  Total number of requests: {}").format(config["limit"] if config["limit"] != 0 else "unlimited")
+    print(("  Total number of requests: {}").format(config["limit"] if config["limit"] != 0 else "unlimited"))
     print("")
     print("Work details:")
-    print("  Priority: {}").format(config["priority"])
-    print("  Weight: {}").format(config["weight"])
-    print("  Start delay: {} s").format(config["when"])
-    print("  Execution time: {} ms").format(config["delay"])
-    print("  Average queue depth: {}").format((effective_rate * config["delay"]) / 1000)
+    print(("  Priority: {}").format(config["priority"]))
+    print(("  Weight: {}").format(config["weight"]))
+    print(("  Start delay: {} s").format(config["when"]))
+    print(("  Execution time: {} ms").format(config["delay"]))
+    print(("  Average queue depth: {}").format((effective_rate * config["delay"]) / 1000))
     print("")
     print("Starting up...")
 

--- a/contrib/performance/jobqueue/workrate.py
+++ b/contrib/performance/jobqueue/workrate.py
@@ -50,7 +50,7 @@ def main():
                 "help",
             ],
         )
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     #

--- a/contrib/performance/loadtest/ical.py
+++ b/contrib/performance/loadtest/ical.py
@@ -15,6 +15,7 @@
 #
 ##
 from __future__ import print_function
+from __future__ import absolute_import
 
 from caldavclientlibrary.protocol.caldav.definitions import caldavxml
 from caldavclientlibrary.protocol.caldav.definitions import csxml
@@ -2814,7 +2815,7 @@ def main():
 
     addObserver(RequestLogger().observe)
 
-    from sim import _DirectoryRecord
+    from .sim import _DirectoryRecord
     client = OS_X_10_6(
         reactor, 'http://127.0.0.1:8008/',
         _DirectoryRecord(

--- a/contrib/performance/loadtest/population.py
+++ b/contrib/performance/loadtest/population.py
@@ -240,7 +240,7 @@ class CalendarClientSimulator(object):
             number = self._nextUserNumber()
 
             for _ignore_peruser in range(clientsPerUser):
-                clientType = self._pop.next()
+                clientType = next(self._pop)
                 if (number % self.workerCount) != self.workerIndex:
                     # If we're in a distributed work scenario and we are worker N,
                     # we have to skip all but every Nth request (since every node

--- a/contrib/performance/loadtest/setup_directory.py
+++ b/contrib/performance/loadtest/setup_directory.py
@@ -95,7 +95,7 @@ def main():
     masterPassword = ""
     try:
         (optargs, args) = getopt(sys.argv[1:], "hn:p:u:", ["help"])
-    except GetoptError, e:
+    except GetoptError as e:
         usage(e)
 
     for opt, arg in optargs:
@@ -150,7 +150,7 @@ def main():
                     print("Failed to set password for %s: %s" % (recordName, error))
                 else:
                     print("Successfully set password for %s" % (recordName,))
-            except ODError, e:
+            except ODError as e:
                 print("Failed to create user %s: %s" % (recordName, e))
         else:
             print("User %s already exists" % (recordName,))

--- a/contrib/performance/loadtest/sim.py
+++ b/contrib/performance/loadtest/sim.py
@@ -203,20 +203,20 @@ class SimOptions(Options):
     def postOptions(self):
         try:
             configFile = self['config'].open()
-        except IOError, e:
+        except IOError as e:
             raise UsageError("--config %s: %s" % (
                 self['config'].path, e.strerror))
         try:
             try:
                 self.config = readPlist(configFile)
-            except ExpatError, e:
+            except ExpatError as e:
                 raise UsageError("--config %s: %s" % (self['config'].path, e))
         finally:
             configFile.close()
 
         try:
             clientFile = self['clients'].open()
-        except IOError, e:
+        except IOError as e:
             raise UsageError("--clients %s: %s" % (
                 self['clients'].path, e.strerror))
         try:
@@ -225,7 +225,7 @@ class SimOptions(Options):
                 self.config["clients"] = client_config["clients"]
                 if "arrivalInterval" in client_config:
                     self.config["arrival"]["params"]["interval"] = client_config["arrivalInterval"]
-            except ExpatError, e:
+            except ExpatError as e:
                 raise UsageError("--clients %s: %s" % (self['clients'].path, e))
         finally:
             clientFile.close()
@@ -277,7 +277,7 @@ class LoadSimulator(object):
         options = SimOptions()
         try:
             options.parseOptions(args)
-        except UsageError, e:
+        except UsageError as e:
             raise SystemExit(str(e))
 
         return cls.fromConfig(options.config, options['runtime'], output)

--- a/contrib/performance/massupload.py
+++ b/contrib/performance/massupload.py
@@ -15,12 +15,13 @@
 ##
 
 from __future__ import print_function
-from benchlib import select
+from __future__ import absolute_import
+from .benchlib import select
 from twisted.internet import reactor
 from twisted.internet.task import coiterate
 from twisted.python.log import err
 from twisted.python.usage import UsageError
-from upload import UploadOptions, upload
+from .upload import UploadOptions, upload
 import sys
 import pickle
 
@@ -41,7 +42,7 @@ def main():
     options = MassUploadOptions()
     try:
         options.parseOptions(sys.argv[1:])
-    except UsageError, e:
+    except UsageError as e:
         print(e)
         return 1
 

--- a/contrib/performance/report.py
+++ b/contrib/performance/report.py
@@ -15,7 +15,8 @@
 ##
 
 from __future__ import print_function
-from benchlib import select
+from __future__ import absolute_import
+from .benchlib import select
 import sys
 import pickle
 

--- a/contrib/performance/report_principals.py
+++ b/contrib/performance/report_principals.py
@@ -18,6 +18,7 @@
 Benchmark a server's response to a simple displayname startswith
 report.
 """
+from __future__ import absolute_import
 
 from urllib2 import HTTPDigestAuthHandler
 
@@ -26,9 +27,9 @@ from twisted.internet import reactor
 from twisted.web.client import Agent
 from twisted.web.http_headers import Headers
 
-from httpauth import AuthHandlerAgent
-from httpclient import StringProducer
-from benchlib import initialize, sample
+from .httpauth import AuthHandlerAgent
+from .httpclient import StringProducer
+from .benchlib import initialize, sample
 
 body = """\
 <?xml version="1.0" encoding="utf-8" ?>

--- a/contrib/performance/simanalysis/sim_regress.py
+++ b/contrib/performance/simanalysis/sim_regress.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 ##
 
+from __future__ import print_function
 import argparse
 import os
 import plistlib

--- a/contrib/performance/sqlwatch.py
+++ b/contrib/performance/sqlwatch.py
@@ -15,7 +15,8 @@
 ##
 
 from __future__ import print_function
-from benchmark import DTraceCollector, instancePIDs
+from __future__ import absolute_import
+from .benchmark import DTraceCollector, instancePIDs
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.python.failure import Failure

--- a/contrib/performance/stats_analysis.py
+++ b/contrib/performance/stats_analysis.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 ##
 # Copyright (c) 2015-2017 Apple Inc. All rights reserved.
 #

--- a/contrib/performance/test_benchmark.py
+++ b/contrib/performance/test_benchmark.py
@@ -17,11 +17,12 @@
 """
 Unit tests for L{benchmark}.
 """
+from __future__ import absolute_import
 
 from twisted.trial.unittest import TestCase
 from twisted.python.usage import UsageError
 
-from benchmark import BenchmarkOptions
+from .benchmark import BenchmarkOptions
 
 
 class BenchmarkOptionsTests(TestCase):

--- a/contrib/performance/test_event_change_date.py
+++ b/contrib/performance/test_event_change_date.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ##
 # Copyright (c) 2010-2017 Apple Inc. All rights reserved.
 #
@@ -16,7 +17,7 @@
 
 from twisted.trial.unittest import TestCase
 
-from benchmarks.event_change_date import replaceTimestamp
+from .benchmarks.event_change_date import replaceTimestamp
 
 calendarHead = """\
 BEGIN:VCALENDAR

--- a/contrib/performance/test_httpauth.py
+++ b/contrib/performance/test_httpauth.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ##
 # Copyright (c) 2012-2017 Apple Inc. All rights reserved.
 #
@@ -15,7 +16,7 @@
 ##
 
 from twisted.trial.unittest import TestCase
-from httpauth import AuthHandlerAgent
+from .httpauth import AuthHandlerAgent
 
 
 class HTTPAuthTests(TestCase):

--- a/contrib/performance/test_stats.py
+++ b/contrib/performance/test_stats.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ##
 # Copyright (c) 2010-2017 Apple Inc. All rights reserved.
 #
@@ -16,7 +17,7 @@
 
 from twisted.trial.unittest import TestCase
 
-from stats import (
+from .stats import (
     SQLDuration, LogNormalDistribution, UniformDiscreteDistribution,
     UniformIntegerDistribution, WorkDistribution, quantize,
     RecurrenceDistribution)

--- a/contrib/performance/upload.py
+++ b/contrib/performance/upload.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 ##
 from __future__ import print_function
+from __future__ import absolute_import
 
 import sys
 import pickle
@@ -26,9 +27,9 @@ from twisted.python.usage import UsageError, Options
 from twisted.internet import reactor
 from twisted.web.client import Agent
 
-from stats import median, mad
-from benchlib import select
-from httpclient import StringProducer, readBody
+from .stats import median, mad
+from .benchlib import select
+from .httpclient import StringProducer, readBody
 
 
 class UploadOptions(Options):
@@ -111,7 +112,7 @@ def main():
     options = UploadOptions()
     try:
         options.parseOptions(sys.argv[1:])
-    except UsageError, e:
+    except UsageError as e:
         print(e)
         return 1
 

--- a/contrib/tools/anonymous_log.py
+++ b/contrib/tools/anonymous_log.py
@@ -51,7 +51,7 @@ class CalendarServerLogAnalyzer(object):
                     line = self.anonymizeLine(line)
                 print(line, end="")
 
-        except Exception, e:
+        except Exception as e:
             print("Exception: %s for %s" % (e, line,))
             raise
 
@@ -162,6 +162,6 @@ if __name__ == "__main__":
 
             CalendarServerLogAnalyzer().anonymizeLogFile(arg)
 
-    except Exception, e:
+    except Exception as e:
         sys.exit(str(e))
         print(traceback.print_exc())

--- a/contrib/tools/buildbot_analyze.py
+++ b/contrib/tools/buildbot_analyze.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 ##
 
+from __future__ import print_function
 from bz2 import BZ2File
 from getopt import getopt
 import os
@@ -108,6 +109,6 @@ if __name__ == "__main__":
         if do_qos:
             qos()
 
-    except Exception, e:
+    except Exception as e:
         raise
         sys.exit(str(e))

--- a/contrib/tools/dtraceanalyze.py
+++ b/contrib/tools/dtraceanalyze.py
@@ -18,13 +18,14 @@
 ##
 from __future__ import print_function
 from __future__ import with_statement
+from __future__ import absolute_import
 
 import collections
 import getopt
 import os
 import re
 import sys
-import tables
+from . import tables
 
 
 class Dtrace(object):
@@ -450,6 +451,6 @@ if __name__ == "__main__":
 
         Dtrace(filepath).analyze(do_stack, no_collapse)
 
-    except Exception, e:
+    except Exception as e:
         raise
         sys.exit(str(e))

--- a/contrib/tools/lldb_utils.py
+++ b/contrib/tools/lldb_utils.py
@@ -50,6 +50,7 @@ pylocals - generate a list of the name and values of all locals in the current
     python frame (only works when the currently selected frame is a Python call
     frame as found by the pybt command).
 """
+from __future__ import print_function
 
 import lldb  # @UnresolvedImport
 

--- a/contrib/tools/monitoranalysis.py
+++ b/contrib/tools/monitoranalysis.py
@@ -49,7 +49,7 @@ def analyze(fpath, noweekends, startDate=None, endDate=None, title=None):
                     digits = line[11:13]
                     if digits in ("05", "06"):
                         for _ignore in range(3):
-                            f.next()
+                            next(f)
                         continue
                     dtstamp = line[:19]
 
@@ -65,15 +65,15 @@ def analyze(fpath, noweekends, startDate=None, endDate=None, title=None):
 
                     lqnon = int(lqnon.split(" ", 1)[0])
 
-                    line = f.next()
+                    line = next(f)
                     cpu = int(line[len("CPU idle %: "):].split(" ", 1)[0])
 
-                    line = f.next()
+                    line = next(f)
                     if line.startswith("Memory"):
-                        line = f.next()
+                        line = next(f)
                     reqs = int(float(line.split(" ", 1)[0]))
 
-                    line = f.next()
+                    line = next(f)
                     resp = line[len("Response time: average "):].split(" ", 1)[0]
                     resp = int(float(resp) / 10.0) * 10
 

--- a/contrib/tools/monitorsplit.py
+++ b/contrib/tools/monitorsplit.py
@@ -55,12 +55,12 @@ def split(fpath, outputDir):
             output = ["-----\n"]
             output.append(line)
             try:
-                output.append(f.next())
-                line = f.next()
+                output.append(next(f))
+                line = next(f)
                 if line.startswith("Memory"):
-                    line = f.next()
+                    line = next(f)
                 output.append(line)
-                output.append(f.next())
+                output.append(next(f))
             except StopIteration:
                 break
             outputFile.write("".join(output))

--- a/contrib/tools/pg_stats_analysis.py
+++ b/contrib/tools/pg_stats_analysis.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 ##
 from __future__ import print_function
+from __future__ import absolute_import
 
 import sqlparse
 import os
 from gzip import GzipFile
 import collections
-import tables
+from . import tables
 import textwrap
 import sys
 import getopt
@@ -55,7 +56,7 @@ def _substitute(expression, replacement):
 def sqlnormalize(sql):
     try:
         statements = sqlparse.parse(sql)
-    except ValueError, e:
+    except ValueError as e:
         print(e)
     # Replace any literal values with placeholders
     qmark = sqlparse.sql.Token('Operator', '?')
@@ -165,7 +166,7 @@ def parseStats(logFilePath, donormlize=True, verbose=False):
         bits = line.split("|")
         if len(bits) > COLUMN_query:
             while bits[COLUMN_query].endswith("+"):
-                line = f.next()
+                line = next(f)
                 newbits = line.split("|")
                 bits[COLUMN_query] = bits[COLUMN_query][:-1] + newbits[COLUMN_query]
 

--- a/contrib/tools/protocolanalysis.py
+++ b/contrib/tools/protocolanalysis.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 ##
 from __future__ import print_function
+from __future__ import absolute_import
 
 from gzip import GzipFile
 import collections
@@ -23,7 +24,7 @@ import getopt
 import os
 import socket
 import sys
-import tables
+from . import tables
 import traceback
 import glob
 from calendarserver.logAnalysis import getAdjustedMethodName, METHOD_PUT_ICS, \
@@ -1872,6 +1873,6 @@ if __name__ == "__main__":
                         analyzers[0].analyzeLogFile(arg)
                     analyzers[0].printAll(doTabDelimited, summary)
 
-    except Exception, e:
+    except Exception as e:
         print(traceback.print_exc())
         sys.exit(str(e))

--- a/contrib/tools/readStats.py
+++ b/contrib/tools/readStats.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 ##
 from __future__ import print_function
+from __future__ import absolute_import
 
 from StringIO import StringIO
 import collections
@@ -23,7 +24,7 @@ import getopt
 import json
 import socket
 import sys
-import tables
+from . import tables
 import time
 import errno
 
@@ -72,7 +73,7 @@ def printStats(stats, multimode, showMethods, topUsers, showAgents, dumpFile):
         else:
             try:
                 summary = printStat(stats[0], multimode[0], showMethods, topUsers, showAgents)
-            except KeyError, e:
+            except KeyError as e:
                 printFailedStats("Unable to find key '%s' in statistics from server socket" % (e,))
                 sys.exit(1)
 
@@ -101,7 +102,7 @@ def printStat(stats, index, showMethods, topUsers, showAgents):
     else:
         print("Current CPU: Unavailable")
         print("Current Memory Used: Unavailable")
-    print
+    print()
     summary = printRequestSummary(stats)
     printHistogramSummary(stats[index], index)
     if showMethods:

--- a/contrib/tools/request_monitor.py
+++ b/contrib/tools/request_monitor.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 ##
 from __future__ import print_function
+from __future__ import absolute_import
 
 from dateutil.parser import parse as dateparse
 from subprocess import Popen, PIPE, STDOUT
@@ -25,7 +26,7 @@ import sys
 import time
 import traceback
 import collections
-import tables
+from . import tables
 from cStringIO import StringIO
 
 # Detect which OS this is being run on
@@ -212,7 +213,7 @@ def freemem():
             line = lines[4]
             freed = int(line.split()[0]) * 1024
             return "%d bytes (%.1f GB)" % (freed, freed / (1024.0 * 1024 * 1024),)
-    except Exception, e:
+    except Exception as e:
         if debug:
             print("freemem failure", e)
             print(traceback.print_exc())
@@ -389,7 +390,7 @@ while True:
 
                 try:
                     userId, logTime, method, uri, status, bytes, _ignore_referer, client, extended = parseLine(line)
-                except Exception, e:
+                except Exception as e:
                     parseErrors += 1
 
                     if debug:
@@ -623,7 +624,7 @@ while True:
         os = StringIO()
         table.printTable(os=os)
         print(os.getvalue())
-        print
+        print()
         if errorCount:
             print("Number of 500 errors: %d" % (errorCount,))
         if parseErrors:
@@ -700,13 +701,13 @@ while True:
             except:
                 pass
 
-        print
+        print()
 
         # lineRange => do loop only once
         if lineRange is not None:
             break
 
-    except Exception, e:
+    except Exception as e:
         print("Script failure", e)
         if debug:
             print(traceback.print_exc())

--- a/contrib/tools/sortrecurrences.py
+++ b/contrib/tools/sortrecurrences.py
@@ -77,6 +77,6 @@ if __name__ == "__main__":
             cal.parse(open(arg))
             print(str(cal.serialize()))
 
-    except Exception, e:
+    except Exception as e:
         sys.exit(str(e))
         print(traceback.print_exc())

--- a/contrib/tools/statsanalysis.py
+++ b/contrib/tools/statsanalysis.py
@@ -51,7 +51,7 @@ def analyze(fpath, title):
         dataset[title] = {}
         json = False
         with open(fpath) as f:
-            line = f.next()
+            line = next(f)
             if line.startswith("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -"):
                 analyzeTableFormat(f, title)
             elif line.startswith("{"):
@@ -90,7 +90,7 @@ def analyzeTableRecord(liter, title):
     @type title: L{str}
     """
 
-    dt = liter.next()
+    dt = next(liter)
     time = dt[11:]
     seconds = 60 * (60 * int(time[0:2]) + int(time[3:5])) + int(time[6:8])
     for line in liter:

--- a/contrib/tools/tables.py
+++ b/contrib/tools/tables.py
@@ -261,7 +261,7 @@ class Table(object):
             colData = ""
 
         columnFormat = format[column] if format and column < len(format) else Table.ColumnFormat()
-        if type(colData) in types.StringTypes:
+        if type(colData) in (str,):
             text = colData
         else:
             text = columnFormat.format % colData

--- a/contrib/tools/test_protocolanalysis.py
+++ b/contrib/tools/test_protocolanalysis.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 ##
 # Copyright (c) 2009-2017 Apple Inc. All rights reserved.
 #
@@ -17,7 +18,7 @@
 from twisted.python.filepath import FilePath
 from twisted.trial.unittest import TestCase
 
-from protocolanalysis import CalendarServerLogAnalyzer
+from .protocolanalysis import CalendarServerLogAnalyzer
 
 
 class UserInteractionTests(TestCase):

--- a/twistedcaldav/accounting.py
+++ b/twistedcaldav/accounting.py
@@ -137,7 +137,7 @@ def emitAccounting(category, record, data, tag=None, filename=None):
 
         return logFilename
 
-    except OSError, e:
+    except OSError as e:
         # No failures in accounting should propagate out
         log.error("Failed to write accounting data due to: {ex}", ex=str(e))
         return None

--- a/twistedcaldav/authkerb.py
+++ b/twistedcaldav/authkerb.py
@@ -77,7 +77,7 @@ class KerberosCredentialFactoryBase(object):
             # the realm and a service principal value for later use.
             try:
                 principal = kerberos.getServerPrincipalDetails(serviceType, hostname)
-            except kerberos.KrbError, ex:
+            except kerberos.KrbError as ex:
                 self.log.error("getServerPrincipalDetails: {ex}", ex=ex[0])
                 raise ValueError('Authentication System Failure: %s' % (ex[0],))
 
@@ -181,7 +181,7 @@ class BasicKerberosCredentialsChecker(object):
         if isinstance(creds, BasicKerberosCredentials):
             try:
                 kerberos.checkPassword(creds.username, creds.password, creds.service, creds.default_realm)
-            except kerberos.BasicAuthError, ex:
+            except kerberos.BasicAuthError as ex:
                 self.log.error("{ex}", ex=ex[0])
                 raise error.UnauthorizedLogin("Bad credentials for: %s (%s: %s)" % (pcreds.authnURI, ex[0], ex[1],))
             else:
@@ -236,18 +236,18 @@ class NegotiateCredentialFactory(KerberosCredentialFactoryBase):
         # name that is case-insenstive as some clients will use "http" instead of "HTTP"
         try:
             _ignore_result, context = kerberos.authGSSServerInit("")
-        except kerberos.GSSError, ex:
+        except kerberos.GSSError as ex:
             self.log.error("authGSSServerInit: {ex0}({ex1})", ex0=ex[0][0], ex1=ex[1][0])
             raise error.LoginFailed('Authentication System Failure: %s(%s)' % (ex[0][0], ex[1][0],))
 
         # Do the GSSAPI step and get response and username
         try:
             kerberos.authGSSServerStep(context, base64data)
-        except kerberos.GSSError, ex:
+        except kerberos.GSSError as ex:
             self.log.error("authGSSServerStep: {ex0}(ex1)", ex0=ex[0][0], ex1=ex[1][0])
             kerberos.authGSSServerClean(context)
             raise error.UnauthorizedLogin('Bad credentials: %s(%s)' % (ex[0][0], ex[1][0],))
-        except kerberos.KrbError, ex:
+        except kerberos.KrbError as ex:
             self.log.error("authGSSServerStep: {ex}", ex=ex[0])
             kerberos.authGSSServerClean(context)
             raise error.UnauthorizedLogin('Bad credentials: %s' % (ex[0],))
@@ -283,7 +283,7 @@ class NegotiateCredentialFactory(KerberosCredentialFactoryBase):
         # Close the context
         try:
             kerberos.authGSSServerClean(context)
-        except kerberos.GSSError, ex:
+        except kerberos.GSSError as ex:
             self.log.error("authGSSServerClean: {ex0}({ex1})", ex0=ex[0][0], ex1=ex[1][0])
             raise error.LoginFailed('Authentication System Failure %s(%s)' % (ex[0][0], ex[1][0],))
 

--- a/twistedcaldav/backup.py
+++ b/twistedcaldav/backup.py
@@ -70,13 +70,13 @@ def logFuncCall(func):
         return ''.join(a).strip(', ')
 
     def _(*args, **kwargs):
-        funclog("%s(%s)" % (func.func_name,
+        funclog("%s(%s)" % (func.__name__,
                             ', '.join((printArgs(args),
                                        printKwargs(kwargs))).strip(', ')))
 
         retval = func(*args, **kwargs)
 
-        funclog("%s - > %s" % (func.func_name, retval))
+        funclog("%s - > %s" % (func.__name__, retval))
 
         return retval
 

--- a/twistedcaldav/cache.py
+++ b/twistedcaldav/cache.py
@@ -415,7 +415,7 @@ class MemcacheResponseCache(BaseResponseCache, CachePoolUserMixIn):
 
             returnValue(r)
 
-        except URINotFoundException, e:
+        except URINotFoundException as e:
             self.log.debug("Could not locate URI: {e!r}", e=e)
             returnValue(None)
 
@@ -463,7 +463,7 @@ class MemcacheResponseCache(BaseResponseCache, CachePoolUserMixIn):
                 key, cacheEntry, expireTime=config.ResponseCacheTimeout * 60
             )
 
-        except URINotFoundException, e:
+        except URINotFoundException as e:
             self.log.debug("Could not locate URI: {e!r}", e=e)
 
         returnValue(response)

--- a/twistedcaldav/client/geturl.py
+++ b/twistedcaldav/client/geturl.py
@@ -86,7 +86,7 @@ def getURL(url, method="GET", redirect=0):
 
     try:
         response = (yield agent.request(method, url, headers, None))
-    except Exception, e:
+    except Exception as e:
         log.error(str(e))
         response = None
     else:

--- a/twistedcaldav/client/pool.py
+++ b/twistedcaldav/client/pool.py
@@ -265,12 +265,12 @@ class HTTPClientPool(object):
 
                 response = (yield self._submitRequest(request, args, kwargs))
 
-            except (ConnectionLost, ConnectionDone, ConnectError), e:
+            except (ConnectionLost, ConnectionDone, ConnectError) as e:
                 self.log.error("HTTP pooled client connection error (attempt: {ctr}) - retrying: {ex}", ctr=ctr + 1, ex=e)
                 continue
 
             # TODO: find the proper cause of these assertions and fix
-            except (AssertionError,), e:
+            except (AssertionError,) as e:
                 self.log.error("HTTP pooled client connection assertion error (attempt: {ctr}) - retrying: {ex}", ctr=ctr + 1, ex=e)
                 continue
 

--- a/twistedcaldav/config.py
+++ b/twistedcaldav/config.py
@@ -361,7 +361,7 @@ def mergeData(oldData, newData):
     @type newData: ConfigDict
     """
     for key, value in newData.iteritems():
-        if isinstance(value, (dict,)):
+        if isinstance(value, dict):
             if key in oldData:
                 assert isinstance(oldData[key], ConfigDict), \
                     "%r in %r is not a ConfigDict" % (oldData[key], oldData)

--- a/twistedcaldav/database.py
+++ b/twistedcaldav/database.py
@@ -163,7 +163,7 @@ class AbstractADBAPIDatabase(object):
         if self.initialized:
             try:
                 self.pool.close()
-            except Exception, e:
+            except Exception as e:
                 log.error("Error whilst closing connection pool: {ex}", ex=e)
             self.pool = None
             self.initialized = False
@@ -178,7 +178,7 @@ class AbstractADBAPIDatabase(object):
 
             try:
                 yield self._db_empty_data_tables()
-            except Exception, e:
+            except Exception as e:
                 log.error("Error in database clean: {ex}", ex=e)
                 self.close()
             else:
@@ -194,7 +194,7 @@ class AbstractADBAPIDatabase(object):
 
             try:
                 yield self._db_execute(sql, *query_params)
-            except Exception, e:
+            except Exception as e:
                 log.error("Error in database execute: {ex}", ex=e)
                 self.close()
             else:
@@ -210,7 +210,7 @@ class AbstractADBAPIDatabase(object):
 
             try:
                 yield self._db_execute_script(script)
-            except Exception, e:
+            except Exception as e:
                 log.error("Error in database executescript: {ex}", ex=e)
                 self.close()
             else:
@@ -226,7 +226,7 @@ class AbstractADBAPIDatabase(object):
 
             try:
                 result = (yield self._db_all_values_for_sql(sql, *query_params))
-            except Exception, e:
+            except Exception as e:
                 log.error("Error in database query: {ex}", ex=e)
                 self.close()
             else:
@@ -244,7 +244,7 @@ class AbstractADBAPIDatabase(object):
 
             try:
                 result = (yield self._db_values_for_sql(sql, *query_params))
-            except Exception, e:
+            except Exception as e:
                 log.error("Error in database queryList: {ex}", ex=e)
                 self.close()
             else:
@@ -262,7 +262,7 @@ class AbstractADBAPIDatabase(object):
 
             try:
                 result = (yield self._db_value_for_sql(sql, *query_params))
-            except Exception, e:
+            except Exception as e:
                 log.error("Error in database queryOne: {ex}", ex=e)
                 self.close()
             else:

--- a/twistedcaldav/directory/calendaruserproxyloader.py
+++ b/twistedcaldav/directory/calendaruserproxyloader.py
@@ -115,7 +115,7 @@ class XMLCalendarUserProxyLoader(object):
 
         def expandCount(value, count):
 
-            if type(value) in types.StringTypes:
+            if type(value) in (str,):
                 return value % (count,) if count and "%" in value else value
             else:
                 return value

--- a/twistedcaldav/directory/digest.py
+++ b/twistedcaldav/directory/digest.py
@@ -164,7 +164,7 @@ class QopDigestCredentialFactory(DigestCredentialFactory):
         c = challenge['nonce']
 
         # Make sure it is not a duplicate
-        result = (yield self.db.has_key(c))  # @IgnorePep8
+        result = (yield c in self.db)  # @IgnorePep8
         if result:
             raise AssertionError("nonce value already cached in credentials database: %s" % (c,))
 

--- a/twistedcaldav/directory/test/test_digest.py
+++ b/twistedcaldav/directory/test/test_digest.py
@@ -215,7 +215,7 @@ class DigestAuthTestCase(TestCase):
     def assertRaisesDeferred(self, exception, f, *args, **kwargs):
         try:
             result = (yield f(*args, **kwargs))
-        except exception, inst:
+        except exception as inst:
             returnValue(inst)
         except:
             raise self.failureException('%s raised instead of %s:\n %s'
@@ -598,7 +598,7 @@ class DigestAuthTestCase(TestCase):
                 self.fail("Nonce should have timed out")
             except error.LoginFailed:
                 self.assertTrue(hasattr(request.remoteAddr, "stale"))
-            except Exception, e:
+            except Exception as e:
                 self.fail("Invalid exception from nonce timeout: %s" % e)
             challenge = (yield factory.getChallenge(request.remoteAddr))
             self.assertTrue(challenge.get("stale") == "true")

--- a/twistedcaldav/directory/util.py
+++ b/twistedcaldav/directory/util.py
@@ -218,7 +218,7 @@ def formatList(iterable):
             else:
                 yield item
             yield "\n"
-    except Exception, e:
+    except Exception as e:
         log.error("Exception while rendering: {ex}", ex=e)
         Failure().printTraceback()
         yield "  ** %s **: %s\n" % (e.__class__.__name__, e)

--- a/twistedcaldav/directory/xmlaugmentsparser.py
+++ b/twistedcaldav/directory/xmlaugmentsparser.py
@@ -79,7 +79,7 @@ class XMLAugmentsParser(object):
         # Read in XML
         try:
             _ignore_tree, augments_node = readXML(self.xmlFile, ELEMENT_AUGMENTS)
-        except ValueError, e:
+        except ValueError as e:
             raise RuntimeError("XML parse error for '%s' because: %s" % (self.xmlFile, e,))
 
         self._parseXML(augments_node)
@@ -135,7 +135,7 @@ class XMLAugmentsParser(object):
 
         def expandCount(value, count):
 
-            if type(value) in types.StringTypes:
+            if type(value) in (str,):
                 return value % (count,) if count and "%" in value else value
             elif type(value) == set:
                 return set([item % (count,) if count and "%" in item else item for item in value])

--- a/twistedcaldav/dumpconfig.py
+++ b/twistedcaldav/dumpconfig.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 ##
 # Copyright (c) 2015-2017 Apple Inc. All rights reserved.
 #

--- a/twistedcaldav/extensions.py
+++ b/twistedcaldav/extensions.py
@@ -219,7 +219,7 @@ class DirectoryPrincipalPropertySearchMixIn(object):
                 try:
                     fieldName, match = principalCollection.propertyToField(
                         prop, match)
-                except ValueError, e:
+                except ValueError as e:
                     raise HTTPError(StatusResponse(responsecode.BAD_REQUEST, str(e)))
                 if fieldName:
                     fields.append((fieldName, match, matchFlags, matchType))
@@ -839,7 +839,7 @@ class DAVFile (WebDAVServerInfoMixIn, SuperDAVFile, DirectoryRenderingMixIn):
 
         try:
             f = self.fp.open()
-        except IOError, e:
+        except IOError as e:
             import errno
             if e[0] == errno.EACCES:
                 return responsecode.FORBIDDEN
@@ -958,7 +958,7 @@ class CachingPropertyStore (object):
 
         try:
             cache = self._cache()
-        except HTTPError, e:
+        except HTTPError as e:
             if e.response.code == responsecode.NOT_FOUND:
                 return False
             else:

--- a/twistedcaldav/ical.py
+++ b/twistedcaldav/ical.py
@@ -455,7 +455,7 @@ class Component (object):
         errmsg = "Unknown"
         try:
             result = Calendar.parseData(data, format)
-        except ErrorBase, e:
+        except ErrorBase as e:
             errmsg = "{0}: {1}".format(e.mReason, e.mData,)
             result = None
         if not result:

--- a/twistedcaldav/localization.py
+++ b/twistedcaldav/localization.py
@@ -408,7 +408,7 @@ def processLocalizationFiles(settings):
                         log.info("Converting {s} to {m}", s=stringsFile, m=moFile)
                         try:
                             convertStringsFile(stringsFile, moFile)
-                        except Exception, e:
+                        except Exception as e:
                             log.error(
                                 "Failed to convert {s} to {m}: {ex}",
                                 s=stringsFile, m=moFile, ex=e,
@@ -484,7 +484,7 @@ def convertStringsFile(src, dest):
 
     result = struct.pack(
         "Iiiiiii",
-        0x950412DEL,           # magic number
+        0x950412DE,           # magic number
         0,                     # file format revision
         len(originals),        # number of strings
         28,                    # offset of table with original strings

--- a/twistedcaldav/memcacheclient.py
+++ b/twistedcaldav/memcacheclient.py
@@ -396,7 +396,7 @@ class Client(local):
                     write("delete %s\r\n" % key)
             try:
                 server.send_cmds(''.join(bigcmd))
-            except socket.error, msg:
+            except socket.error as msg:
                 rc = 0
                 if isinstance(msg, tuple):
                     msg = msg[1]
@@ -411,7 +411,7 @@ class Client(local):
             try:
                 for key in keys:
                     server.expect("DELETED")
-            except socket.error, msg:
+            except socket.error as msg:
                 if isinstance(msg, tuple):
                     msg = msg[1]
                 server.mark_dead(msg)
@@ -438,7 +438,7 @@ class Client(local):
         try:
             server.send_cmd(cmd)
             server.expect("DELETED")
-        except socket.error, msg:
+        except socket.error as msg:
             if isinstance(msg, tuple):
                 msg = msg[1]
             server.mark_dead(msg)
@@ -493,7 +493,7 @@ class Client(local):
             server.send_cmd(cmd)
             line = server.readline()
             return int(line)
-        except socket.error, msg:
+        except socket.error as msg:
             if isinstance(msg, tuple):
                 msg = msg[1]
             server.mark_dead(msg)
@@ -664,7 +664,7 @@ class Client(local):
                     store_info = self._val_to_store_info(mapping[prefixed_to_orig_key[key]], min_compress_len)
                     write("set %s %d %d %d\r\n%s\r\n" % (key, store_info[0], time, store_info[1], store_info[2]))
                 server.send_cmds(''.join(bigcmd))
-            except socket.error, msg:
+            except socket.error as msg:
                 if isinstance(msg, tuple):
                     msg = msg[1]
                 server.mark_dead(msg)
@@ -687,7 +687,7 @@ class Client(local):
                         continue
                     else:
                         notstored.append(prefixed_to_orig_key[key])  # un-mangle.
-            except (_Error, socket.error), msg:
+            except (_Error, socket.error) as msg:
                 if isinstance(msg, tuple):
                     msg = msg[1]
                 server.mark_dead(msg)
@@ -774,7 +774,7 @@ class Client(local):
 
             return False
 
-        except socket.error, msg:
+        except socket.error as msg:
             if isinstance(msg, tuple):
                 msg = msg[1]
             server.mark_dead(msg)
@@ -799,7 +799,7 @@ class Client(local):
                 return None
             value = self._recv_value(server, flags, rlen)
             server.expect("END")
-        except (_Error, socket.error), msg:
+        except (_Error, socket.error) as msg:
             if isinstance(msg, tuple):
                 msg = msg[1]
             server.mark_dead(msg)
@@ -825,7 +825,7 @@ class Client(local):
                 return (None, None)
             value = self._recv_value(server, flags, rlen)
             server.expect("END")
-        except (_Error, socket.error), msg:
+        except (_Error, socket.error) as msg:
             if isinstance(msg, tuple):
                 msg = msg[1]
             server.mark_dead(msg)
@@ -879,7 +879,7 @@ class Client(local):
         for server in server_keys.iterkeys():
             try:
                 server.send_cmd("get %s" % " ".join(server_keys[server]))
-            except socket.error, msg:
+            except socket.error as msg:
                 if isinstance(msg, tuple):
                     msg = msg[1]
                 server.mark_dead(msg)
@@ -903,7 +903,7 @@ class Client(local):
                         except KeyError:
                             pass
                     line = server.readline()
-            except (_Error, socket.error), msg:
+            except (_Error, socket.error) as msg:
                 if isinstance(msg, tuple):
                     msg = msg[1]
                 server.mark_dead(msg)
@@ -924,7 +924,7 @@ class Client(local):
         for server in server_keys.iterkeys():
             try:
                 server.send_cmd("gets %s" % " ".join(server_keys[server]))
-            except socket.error, msg:
+            except socket.error as msg:
                 if isinstance(msg, tuple):
                     msg = msg[1]
                 server.mark_dead(msg)
@@ -948,7 +948,7 @@ class Client(local):
                         except KeyError:
                             pass
                     line = server.readline()
-            except (_Error, socket.error), msg:
+            except (_Error, socket.error) as msg:
                 if isinstance(msg, tuple):
                     msg = msg[1]
                 server.mark_dead(msg)
@@ -1004,7 +1004,7 @@ class Client(local):
                 if self.persistent_load:
                     unpickler.persistent_load = self.persistent_load
                 val = unpickler.load()
-            except Exception, e:
+            except Exception as e:
                 self.debuglog('Pickle error: %s\n' % e)
                 val = None
         else:
@@ -1165,7 +1165,7 @@ class _Host:
     _SOCKET_TIMEOUT = 3  # number of seconds before sockets timeout.
 
     def __init__(self, host, debugfunc=None):
-        if isinstance(host, types.TupleType):
+        if isinstance(host, tuple):
             host, self.weight = host
         else:
             self.weight = 1
@@ -1228,11 +1228,11 @@ class _Host:
             s.settimeout(self._SOCKET_TIMEOUT)
         try:
             s.connect(self.address)
-        except socket.timeout, msg:
+        except socket.timeout as msg:
             log.error("Memcacheclient _get_socket() connection timed out ({m})", m=msg)
             self.mark_dead("connect: %s" % msg)
             return None
-        except socket.error, msg:
+        except socket.error as msg:
             if isinstance(msg, tuple):
                 msg = msg[1]
             log.error("Memcacheclient _get_socket() connection error ({m})", m=msg)
@@ -1286,7 +1286,7 @@ class _Host:
             foo = self_socket_recv(4096)
             buf += foo
             if len(foo) == 0:
-                raise _Error, (
+                raise _Error(
                     'Read %d bytes, expecting %d, '
                     'read returned 0 length bytes' % (len(buf), rlen))
         self.buffer = buf[rlen:]
@@ -1318,23 +1318,23 @@ def check_key(key, key_extra_len=0):
     if isinstance(key, tuple):
         key = key[1]
     if not key:
-        raise Client.MemcachedKeyNoneError, ("Key is None")
+        raise Client.MemcachedKeyNoneError(("Key is None"))
     if isinstance(key, unicode):
-        raise Client.MemcachedStringEncodingError, (
+        raise Client.MemcachedStringEncodingError(
             "Keys must be str()'s, not "
             "unicode.  Convert your unicode strings using "
             "mystring.encode(charset)!")
     if not isinstance(key, str):
-        raise Client.MemcachedKeyTypeError, ("Key must be str()'s")
+        raise Client.MemcachedKeyTypeError(("Key must be str()'s"))
 
     if isinstance(key, basestring):
         if len(key) + key_extra_len > SERVER_MAX_KEY_LENGTH:
-            raise Client.MemcachedKeyLengthError, (
+            raise Client.MemcachedKeyLengthError(
                 "Key length is > %s"
                 % SERVER_MAX_KEY_LENGTH)
         for char in key:
             if ord(char) < 32 or ord(char) == 127:
-                raise Client.MemcachedKeyCharacterError, "Control characters not allowed"
+                raise Client.MemcachedKeyCharacterError("Control characters not allowed")
 
 
 def _doctest():
@@ -1349,7 +1349,7 @@ if __name__ == "__main__":
     print("Testing docstrings...")
     _doctest()
     print("Running tests:")
-    print
+    print()
     serverList = [["127.0.0.1:11211"]]
     if '--do-unix' in sys.argv:
         serverList.append([os.path.join(os.getcwd(), 'memcached.socket')])
@@ -1358,7 +1358,7 @@ if __name__ == "__main__":
         mc = Client(servers, debug=1)
 
         def to_s(val):
-            if not isinstance(val, types.StringTypes):
+            if not isinstance(val, str):
                 return "%s (%s)" % (val, type(val))
             return "%s" % val
 
@@ -1421,7 +1421,7 @@ if __name__ == "__main__":
         print("Testing sending spaces...", end="")
         try:
             x = mc.set("this has spaces", 1)
-        except Client.MemcachedKeyCharacterError, msg:
+        except Client.MemcachedKeyCharacterError as msg:
             print("OK")
         else:
             print("FAIL")
@@ -1429,7 +1429,7 @@ if __name__ == "__main__":
         print("Testing sending control characters...", end="")
         try:
             x = mc.set("this\x10has\x11control characters\x02", 1)
-        except Client.MemcachedKeyCharacterError, msg:
+        except Client.MemcachedKeyCharacterError as msg:
             print("OK")
         else:
             print("FAIL")
@@ -1437,7 +1437,7 @@ if __name__ == "__main__":
         print("Testing using insanely long key...", end="")
         try:
             x = mc.set('a' * SERVER_MAX_KEY_LENGTH + 'aaaa', 1)
-        except Client.MemcachedKeyLengthError, msg:
+        except Client.MemcachedKeyLengthError as msg:
             print("OK")
         else:
             print("FAIL")
@@ -1445,7 +1445,7 @@ if __name__ == "__main__":
         print("Testing sending a unicode-string key...", end="")
         try:
             x = mc.set(u'keyhere', 1)
-        except Client.MemcachedStringEncodingError, msg:
+        except Client.MemcachedStringEncodingError as msg:
             print("OK", end="")
         else:
             print("FAIL", end="")

--- a/twistedcaldav/method/mkcalendar.py
+++ b/twistedcaldav/method/mkcalendar.py
@@ -73,7 +73,7 @@ def http_MKCALENDAR(self, request):
     try:
         doc = (yield davXMLFromStream(request.stream))
         yield self.createCalendar(request)
-    except ValueError, e:
+    except ValueError as e:
         log.error("Error while handling MKCALENDAR: {ex}", ex=e)
         raise HTTPError(StatusResponse(responsecode.BAD_REQUEST, str(e)))
 

--- a/twistedcaldav/method/mkcol.py
+++ b/twistedcaldav/method/mkcol.py
@@ -96,7 +96,7 @@ def http_MKCOL(self, request):
     #
     try:
         doc = (yield davXMLFromStream(request.stream))
-    except ValueError, e:
+    except ValueError as e:
         log.error("Error while handling MKCOL: {ex}", ex=e)
         # TODO: txweb2.dav 'MKCOL' tests demand this particular response
         # code, but should we really be looking at the XML content or the

--- a/twistedcaldav/method/propfind.py
+++ b/twistedcaldav/method/propfind.py
@@ -71,7 +71,7 @@ def http_PROPFIND(self, request):
     #
     try:
         doc = (yield davXMLFromStream(request.stream))
-    except ValueError, e:
+    except ValueError as e:
         log.error("Error while handling PROPFIND body: {ex}", ex=e)
         raise HTTPError(StatusResponse(responsecode.BAD_REQUEST, str(e)))
 

--- a/twistedcaldav/method/report.py
+++ b/twistedcaldav/method/report.py
@@ -58,7 +58,7 @@ def http_REPORT(self, request):
     #
     try:
         doc = (yield davXMLFromStream(request.stream))
-    except ValueError, e:
+    except ValueError as e:
         log.error("Error while handling REPORT body: {err}", err=str(e))
         raise HTTPError(StatusResponse(responsecode.BAD_REQUEST, str(e)))
 

--- a/twistedcaldav/method/report_addressbook_query.py
+++ b/twistedcaldav/method/report_addressbook_query.py
@@ -262,7 +262,7 @@ def report_urn_ietf_params_xml_ns_carddav_addressbook_query(self, request, addre
     try:
         depth = request.headers.getHeader("depth", "0")
         yield report_common.applyToAddressBookCollections(self, request, request.uri, depth, doQuery, (davxml.Read(),))
-    except NumberOfMatchesWithinLimits, e:
+    except NumberOfMatchesWithinLimits as e:
         self.log.info("Too many matching components in addressbook-query report. Limited to {limit} items", limit=e.maxLimit())
         responses.append(davxml.StatusResponse(
             davxml.HRef.fromString(request.uri),

--- a/twistedcaldav/method/report_calendar_query.py
+++ b/twistedcaldav/method/report_calendar_query.py
@@ -265,7 +265,7 @@ def report_urn_ietf_params_xml_ns_caldav_calendar_query(self, request, calendar_
     try:
         depth = request.headers.getHeader("depth", "0")
         yield report_common.applyToCalendarCollections(self, request, request.uri, depth, doQuery, (davxml.Read(),))
-    except TooManyInstancesError, ex:
+    except TooManyInstancesError as ex:
         log.error("Too many instances need to be computed in calendar-query report")
         raise HTTPError(ErrorResponse(
             responsecode.FORBIDDEN,
@@ -279,13 +279,13 @@ def report_urn_ietf_params_xml_ns_caldav_calendar_query(self, request, calendar_
             davxml.NumberOfMatchesWithinLimits(),
             "Too many components",
         ))
-    except TimeRangeLowerLimit, e:
+    except TimeRangeLowerLimit as e:
         raise HTTPError(ErrorResponse(
             responsecode.FORBIDDEN,
             caldavxml.MinDateTime(),
             "Time-range value too far in the past. Must be on or after %s." % (str(e.limit),)
         ))
-    except TimeRangeUpperLimit, e:
+    except TimeRangeUpperLimit as e:
         raise HTTPError(ErrorResponse(
             responsecode.FORBIDDEN,
             caldavxml.MaxDateTime(),

--- a/twistedcaldav/method/report_common.py
+++ b/twistedcaldav/method/report_common.py
@@ -87,7 +87,7 @@ def applyToCalendarCollections(resource, request, request_uri, depth, apply, pri
         yield resource.findCalendarCollections(depth, request, lambda x, y: resources.append((x, y)), privileges=privileges)
 
     for calresource, uri in resources:
-        result = (yield apply(calresource, uri))
+        result = (yield calresource(*uri))
         if not result:
             break
 
@@ -125,7 +125,7 @@ def applyToAddressBookCollections(resource, request, request_uri, depth, apply, 
         yield resource.findAddressBookCollections(depth, request, lambda x, y: resources.append((x, y)), privileges=privileges)
 
     for addrresource, uri in resources:
-        result = yield apply(addrresource, uri)
+        result = yield addrresource(*uri)
         if not result:
             break
 

--- a/twistedcaldav/method/report_freebusy.py
+++ b/twistedcaldav/method/report_freebusy.py
@@ -98,13 +98,13 @@ def report_urn_ietf_params_xml_ns_caldav_free_busy_query(self, request, freebusy
             davxml.NumberOfMatchesWithinLimits(),
             "Too many components"
         ))
-    except TimeRangeLowerLimit, e:
+    except TimeRangeLowerLimit as e:
         raise HTTPError(ErrorResponse(
             responsecode.FORBIDDEN,
             caldavxml.MinDateTime(),
             "Time-range value too far in the past. Must be on or after %s." % (str(e.limit),)
         ))
-    except TimeRangeUpperLimit, e:
+    except TimeRangeUpperLimit as e:
         raise HTTPError(ErrorResponse(
             responsecode.FORBIDDEN,
             caldavxml.MaxDateTime(),

--- a/twistedcaldav/resource.py
+++ b/twistedcaldav/resource.py
@@ -942,7 +942,7 @@ class CalDAVResource (
 
         try:
             resourcetype = self.resourceType()
-        except HTTPError, e:
+        except HTTPError as e:
             assert e.response.code == responsecode.NOT_FOUND, (
                 "Unexpected response code: %s" % (e.response.code,)
             )
@@ -1316,7 +1316,7 @@ class CalDAVResource (
                                     etag=etag,
                                     lastModified=last_modified,
                                 )
-                            except HTTPError, e:
+                            except HTTPError as e:
                                 last_exception = e
                             else:
                                 break

--- a/twistedcaldav/sharing.py
+++ b/twistedcaldav/sharing.py
@@ -756,7 +756,7 @@ class SharedResourceMixin(object):
         xmldata = (yield allDataFromStream(request.stream))
         try:
             doc = element.WebDAVDocument.fromString(xmldata)
-        except ValueError, e:
+        except ValueError as e:
             self.log.error("Error parsing doc ({ex}) Doc:\n {x}", ex=str(e), x=xmldata)
             raise HTTPError(ErrorResponse(
                 responsecode.FORBIDDEN,

--- a/twistedcaldav/stdconfig.py
+++ b/twistedcaldav/stdconfig.py
@@ -189,7 +189,7 @@ DEFAULT_CONFIG = {
         "Unsecured": "unsecured.sock",  # Socket file to listen for insecure requests on
         "Owner": "",
         "Group": "",
-        "Permissions": 0770,
+        "Permissions": 0o770,
     },
     "SocketRoot": "/tmp/calendarserver",
 
@@ -993,7 +993,7 @@ DEFAULT_CONFIG = {
     },
 
     # Umask
-    "umask": 0022,
+    "umask": 0o022,
 
     # A TCP port used for communication between the child and master
     # processes (bound to 127.0.0.1). Specify 0 to let OS assign a port.
@@ -1644,7 +1644,7 @@ def _updateRejectClients(configDict, reloading=False):
     #
     try:
         configDict.RejectClients = [re.compile(x) for x in configDict.RejectClients if x]
-    except re.error, e:
+    except re.error as e:
         raise ConfigurationError("Invalid regular expression in RejectClients: %s" % (e,))
 
 
@@ -1656,7 +1656,7 @@ def _updateClientFixes(configDict, reloading=False):
         configDict.ClientFixesCompiled = {}
         for key, expressions in configDict.ClientFixes.items():
             configDict.ClientFixesCompiled[key] = [re.compile("^{}$".format(x)) for x in expressions]
-    except re.error, e:
+    except re.error as e:
         raise ConfigurationError("Invalid regular expression in ClientFixes: %s" % (e,))
 
 
@@ -1682,7 +1682,7 @@ def _updateLogLevels(configDict, reloading=False):
                     namespace, LogLevel.levelWithName(levelName)
                 )
 
-    except InvalidLogLevelError, e:
+    except InvalidLogLevelError as e:
         raise ConfigurationError("Invalid log level: %s" % (e.level))
 
 

--- a/twistedcaldav/storebridge.py
+++ b/twistedcaldav/storebridge.py
@@ -725,7 +725,7 @@ class _CommonHomeChildCollectionMixin(_CommonStoreExceptionHandler):
                 newchild = (yield request.locateResource(newchildURL))
                 changedComponent = (yield self.storeResourceData(newchild, component, returnChangedData=return_changed))
 
-            except HTTPError, e:
+            except HTTPError as e:
                 # Extract the pre-condition
                 code = e.response.code
                 if isinstance(e.response, ErrorResponse):
@@ -870,7 +870,7 @@ class _CommonHomeChildCollectionMixin(_CommonStoreExceptionHandler):
             try:
                 yield self.authorize(request, (davxml.Bind(),))
                 hasPrivilege = True
-            except HTTPError, e:
+            except HTTPError as e:
                 hasPrivilege = e
 
             # get components
@@ -924,7 +924,7 @@ class _CommonHomeChildCollectionMixin(_CommonStoreExceptionHandler):
                 changedComponent = yield self.storeResourceData(updateResource, component, returnChangedData=return_changed)
                 etag = (yield updateResource.etag())
 
-            except HTTPError, e:
+            except HTTPError as e:
                 # Extract the pre-condition
                 code = e.response.code
                 if isinstance(e.response, ErrorResponse):
@@ -974,7 +974,7 @@ class _CommonHomeChildCollectionMixin(_CommonStoreExceptionHandler):
             try:
                 yield self.authorize(request, (davxml.Unbind(),))
                 hasPrivilege = True
-            except HTTPError, e:
+            except HTTPError as e:
                 hasPrivilege = e
 
             for index, href, ifmatch in crudDeleteInfo:
@@ -995,7 +995,7 @@ class _CommonHomeChildCollectionMixin(_CommonStoreExceptionHandler):
 
                     yield deleteResource.storeRemove(request)
 
-                except HTTPError, e:
+                except HTTPError as e:
                     # Extract the pre-condition
                     code = e.response.code
                     if isinstance(e.response, ErrorResponse):
@@ -2077,7 +2077,7 @@ class CalendarAttachment(_NewStoreFileMetaDataHelper, _GetChildHelper):
             log.error("Dropbox cannot be used after migration to managed attachments")
             raise HTTPError(FORBIDDEN)
 
-        except Exception, e:
+        except Exception as e:
             log.error("Unable to store attachment: {ex}", ex=e)
             raise HTTPError(SERVICE_UNAVAILABLE)
 
@@ -2116,7 +2116,7 @@ class CalendarAttachment(_NewStoreFileMetaDataHelper, _GetChildHelper):
                 stream.finish()
         try:
             self._newStoreAttachment.retrieve(StreamProtocol())
-        except IOError, e:
+        except IOError as e:
             log.error("Unable to read attachment: {s!r}, due to: {ex}", s=self, ex=e)
             raise HTTPError(NOT_FOUND)
 
@@ -2655,7 +2655,7 @@ class CalendarObjectResource(_CalendarObjectMetaDataMixin, _CommonObjectResource
                                     etag=etag,
                                     lastModified=last_modified,
                                 )
-                            except HTTPError, e:
+                            except HTTPError as e:
                                 last_exception = e
                             else:
                                 break
@@ -2735,7 +2735,7 @@ class CalendarObjectResource(_CalendarObjectMetaDataMixin, _CommonObjectResource
 
             try:
                 component = Component.fromString(calendardata, format)
-            except ValueError, e:
+            except ValueError as e:
                 log.error(str(e))
                 raise HTTPError(ErrorResponse(
                     responsecode.FORBIDDEN,
@@ -3221,12 +3221,12 @@ class AddressBookCollectionResource(_CommonHomeChildCollectionMixin, CalDAVResou
                 newchild = (yield request.locateResource(newchildURL))
                 changedComponent = (yield self.storeResourceData(newchild, component, returnChangedData=return_changed))
 
-            except GroupWithUnsharedAddressNotAllowedError, e:
+            except GroupWithUnsharedAddressNotAllowedError as e:
                 # save off info and try again below
                 missingUIDs = set(e.message)
                 groupRetries.append((index, component, newchildURL, newchild, missingUIDs,))
 
-            except HTTPError, e:
+            except HTTPError as e:
                 # Extract the pre-condition
                 code = e.response.code
                 if isinstance(e.response, ErrorResponse):
@@ -3292,7 +3292,7 @@ class AddressBookCollectionResource(_CommonHomeChildCollectionMixin, CalDAVResou
             try:
                 yield self.authorize(request, (davxml.Unbind(),))
                 hasPrivilege = True
-            except HTTPError, e:
+            except HTTPError as e:
                 hasPrivilege = e
 
             for index, href, ifmatch in crudDeleteInfo:
@@ -3330,7 +3330,7 @@ class AddressBookCollectionResource(_CommonHomeChildCollectionMixin, CalDAVResou
 
                     yield deleteResource.storeRemove(request)
 
-                except HTTPError, e:
+                except HTTPError as e:
                     # Extract the pre-condition
                     code = e.response.code
                     if isinstance(e.response, ErrorResponse):
@@ -3476,7 +3476,7 @@ class AddressBookObjectResource(_CommonObjectResource):
 
             try:
                 component = VCard.fromString(vcarddata, format)
-            except ValueError, e:
+            except ValueError as e:
                 log.error(str(e))
                 raise HTTPError(ErrorResponse(
                     responsecode.FORBIDDEN,

--- a/twistedcaldav/test/data/csv2ical.py
+++ b/twistedcaldav/test/data/csv2ical.py
@@ -23,6 +23,7 @@
 # Dedicated to Amir.
 #
 
+from __future__ import print_function
 import sys
 import csv
 import datetime
@@ -73,7 +74,7 @@ reader = csv.reader(file(csv_filename, "rb"))
 calendar = Component("VCALENDAR")
 
 # Ignore first line
-reader.next()
+next(reader)
 
 priorities = {
     "High": "1",
@@ -110,4 +111,4 @@ for row in reader:
 
     calendar.addComponent(event)
 
-print calendar
+print(calendar)

--- a/twistedcaldav/test/data/makelargecalendars.py
+++ b/twistedcaldav/test/data/makelargecalendars.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 ##
 
+from __future__ import print_function
 import getopt
 import os
 import sys
@@ -37,7 +38,7 @@ if __name__ == "__main__":
         elif option == "-d":
             document_root = os.path.abspath(value)
         else:
-            print "Unrecognized option: %s" % (option,)
+            print("Unrecognized option: %s" % (option,))
             raise ValueError
 
     for ctr in (xrange(user_one, user_one + 1) if user_one else xrange(1, user_max + 1)):
@@ -55,7 +56,7 @@ if __name__ == "__main__":
 
         for calendar in calendars:
             if not os.path.isdir(os.path.join(path, calendar)):
-                print "Expanding %s to %s" % (calendar, path)
+                print("Expanding %s to %s" % (calendar, path))
                 cmd = "tar -C %r -zx -f %r" % (path,
                                                os.path.join(wd,
                                                             calendar + ".tgz"))

--- a/twistedcaldav/test/data/makelargefbset.py
+++ b/twistedcaldav/test/data/makelargefbset.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 ##
 
+from __future__ import print_function
 import getopt
 import os
 import sys
@@ -31,7 +32,7 @@ if __name__ == "__main__":
         if option == "-n":
             user_max = int(value)
         else:
-            print "Unrecognized option: %s" % (option,)
+            print("Unrecognized option: %s" % (option,))
             raise ValueError
 
     for ctr in xrange(1, user_max + 1):

--- a/twistedcaldav/test/data/split_holidays.py
+++ b/twistedcaldav/test/data/split_holidays.py
@@ -22,6 +22,7 @@
 # These split-up calendars are useable as CalDAV resources.
 #
 
+from __future__ import print_function
 import os
 
 from twistedcaldav.ical import Component
@@ -47,7 +48,7 @@ for subcomponent in calendar.subcomponents():
     uid = subcalendar.resourceUID()
     subcalendar_filename = os.path.join(os.path.dirname(__file__), "Holidays", uid + ".ics")
 
-    print "Writing %s" % (subcalendar_filename,)
+    print("Writing %s" % (subcalendar_filename,))
 
     subcalendar_file = file(subcalendar_filename, "w")
     try:

--- a/twistedcaldav/test/test_database.py
+++ b/twistedcaldav/test/test_database.py
@@ -107,7 +107,7 @@ class Database (twistedcaldav.test.util.TestCase):
             yield f(*args, **kwargs)
         except exc:
             pass
-        except Exception, e:
+        except Exception as e:
             self.fail("Wrong exception raised: %s" % (e,))
         else:
             self.fail("%s not raised" % (exc,))

--- a/twistedcaldav/test/test_kerberos.py
+++ b/twistedcaldav/test/test_kerberos.py
@@ -66,7 +66,7 @@ class KerberosTests(twistedcaldav.test.util.TestCase):
             yield factory.decode("Bogus Data".encode("base64"), request)
         except (UnauthorizedLogin, LoginFailed):
             pass
-        except Exception, ex:
+        except Exception as ex:
             self.fail(msg="NegotiateCredentialFactory decode failed with exception: %s" % (ex,))
         else:
             self.fail(msg="NegotiateCredentialFactory decode did not fail")

--- a/twistedcaldav/test/test_link.py
+++ b/twistedcaldav/test/test_link.py
@@ -81,7 +81,7 @@ class LinkResourceTests(TestCase):
         request = SimpleRequest(self.site, "GET", "/home/link/")
         try:
             yield resource.locateChild(request, ["link", ])
-        except HTTPError, e:
+        except HTTPError as e:
             self.assertEqual(e.response.code, responsecode.NOT_FOUND)
         else:
             self.fail("HTTPError exception not raised")
@@ -98,7 +98,7 @@ class LinkResourceTests(TestCase):
         request = SimpleRequest(self.site, "GET", "/home/link1/")
         try:
             yield resource.locateChild(request, ["link1", ])
-        except HTTPError, e:
+        except HTTPError as e:
             self.assertEqual(e.response.code, responsecode.LOOP_DETECTED)
         else:
             self.fail("HTTPError exception not raised")

--- a/twistedcaldav/test/test_memcachelock.py
+++ b/twistedcaldav/test/test_memcachelock.py
@@ -185,7 +185,7 @@ class MemCacheTestCase(TestCase):
             )
         except MemcacheLockTimeoutError:
             pass
-        except Exception, e:
+        except Exception as e:
             self.fail("Unknown exception thrown: %s" % (e,))
         else:
             self.fail("No timeout exception thrown")

--- a/twistedcaldav/test/test_timezones.py
+++ b/twistedcaldav/test/test_timezones.py
@@ -68,8 +68,8 @@ class TimezoneProblemTest (twistedcaldav.test.util.TestCase):
 
         self.doTest(
             "TruncatedApr01.ics",
-            DateTime(2007, 04, 01, 16, 0, 0, Timezone.UTCTimezone),
-            DateTime(2007, 04, 01, 17, 0, 0, Timezone.UTCTimezone)
+            DateTime(2007, 0o4, 0o1, 16, 0, 0, Timezone.UTCTimezone),
+            DateTime(2007, 0o4, 0o1, 17, 0, 0, Timezone.UTCTimezone)
         )
 
     def test_truncatedDec(self):
@@ -96,8 +96,8 @@ class TimezoneProblemTest (twistedcaldav.test.util.TestCase):
 
         self.doTest(
             "TruncatedApr01.ics",
-            DateTime(2007, 04, 01, 16, 0, 0, Timezone.UTCTimezone),
-            DateTime(2007, 04, 01, 17, 0, 0, Timezone.UTCTimezone),
+            DateTime(2007, 0o4, 0o1, 16, 0, 0, Timezone.UTCTimezone),
+            DateTime(2007, 0o4, 0o1, 17, 0, 0, Timezone.UTCTimezone),
         )
         self.doTest(
             "TruncatedDec10.ics",
@@ -115,8 +115,8 @@ class TimezoneProblemTest (twistedcaldav.test.util.TestCase):
 
         self.doTest(
             "TruncatedApr01.ics",
-            DateTime(2007, 04, 01, 16, 0, 0, Timezone.UTCTimezone),
-            DateTime(2007, 04, 01, 17, 0, 0, Timezone.UTCTimezone),
+            DateTime(2007, 0o4, 0o1, 16, 0, 0, Timezone.UTCTimezone),
+            DateTime(2007, 0o4, 0o1, 17, 0, 0, Timezone.UTCTimezone),
         )
         self.doTest(
             "TruncatedDec10.ics",
@@ -139,8 +139,8 @@ class TimezoneProblemTest (twistedcaldav.test.util.TestCase):
         )
         self.doTest(
             "TruncatedApr01.ics",
-            DateTime(2007, 04, 01, 16, 0, 0, Timezone.UTCTimezone),
-            DateTime(2007, 04, 01, 17, 0, 0, Timezone.UTCTimezone)
+            DateTime(2007, 0o4, 0o1, 16, 0, 0, Timezone.UTCTimezone),
+            DateTime(2007, 0o4, 0o1, 17, 0, 0, Timezone.UTCTimezone)
         )
 
 
@@ -199,8 +199,8 @@ END:VCALENDAR
             instance = instances[key]
             start = instance.start
             end = instance.end
-            self.assertEqual(start, DateTime(2007, 12, 25, 05, 0, 0, Timezone.UTCTimezone))
-            self.assertEqual(end, DateTime(2007, 12, 25, 06, 0, 0, Timezone.UTCTimezone))
+            self.assertEqual(start, DateTime(2007, 12, 25, 0o5, 0, 0, Timezone.UTCTimezone))
+            self.assertEqual(end, DateTime(2007, 12, 25, 0o6, 0, 0, Timezone.UTCTimezone))
             break
 
     def test_getTZExtrasPath(self):

--- a/twistedcaldav/test/test_wrapping.py
+++ b/twistedcaldav/test/test_wrapping.py
@@ -371,7 +371,7 @@ class WrappingTests(StoreTestCase):
             "x" * deriveQuota(self) * 2)
         try:
             result = yield calendarObject.http_PUT(self.requestUnderTest)
-        except HTTPError, he:
+        except HTTPError as he:
             self.assertEquals(he.response.code, INSUFFICIENT_STORAGE_SPACE)
         else:
             self.fail("Error not raised, %r returned instead." %

--- a/twistedcaldav/timezonestdservice.py
+++ b/twistedcaldav/timezonestdservice.py
@@ -682,7 +682,7 @@ class PrimaryTimezoneDatabase(CommonTimezoneDatabase):
         try:
             with open(os.path.join(self.basepath, "links.txt")) as f:
                 aliases = f.read()
-        except IOError, e:
+        except IOError as e:
             log.error("Unable to read links.txt file: {ex}", ex=str(e))
             aliases = ""
 
@@ -887,7 +887,7 @@ class SecondaryTimezoneDatabase(CommonTimezoneDatabase):
                 os.makedirs(os.path.dirname(tzpath))
             with open(tzpath, "w") as f:
                 f.write(ical)
-        except IOError, e:
+        except IOError as e:
             log.error("Unable to write calendar file for {tzid}: {ex}", tzid=tzinfo.tzid, ex=str(e))
         else:
             self.timezones[tzinfo.tzid] = tzinfo
@@ -897,5 +897,5 @@ class SecondaryTimezoneDatabase(CommonTimezoneDatabase):
         try:
             os.remove(tzpath)
             del self.timezones[tzid]
-        except IOError, e:
+        except IOError as e:
             log.error("Unable to write calendar file for {tzid}: {ex}", tzid=tzid, ex=str(e))

--- a/twistedcaldav/upgrade.py
+++ b/twistedcaldav/upgrade.py
@@ -149,7 +149,7 @@ def upgradeCalendarCollection(calPath, directory, cuaCache):
                 if fixed:
                     log.warn("Fixing bad quotes in {path}", path=resPath)
                     needsRewrite = True
-            except Exception, e:
+            except Exception as e:
                 log.error(
                     "Error while fixing bad quotes in {path}: {ex}",
                     path=resPath, ex=e,
@@ -162,7 +162,7 @@ def upgradeCalendarCollection(calPath, directory, cuaCache):
                 if fixed:
                     log.warn("Removing illegal characters in {path}", path=resPath)
                     needsRewrite = True
-            except Exception, e:
+            except Exception as e:
                 log.error(
                     "Error while removing illegal characters in {path}: {ex}",
                     path=resPath, ex=e,
@@ -175,7 +175,7 @@ def upgradeCalendarCollection(calPath, directory, cuaCache):
                 if fixed:
                     log.debug("Normalized CUAddrs in {path}", path=resPath)
                     needsRewrite = True
-            except Exception, e:
+            except Exception as e:
                 log.error(
                     "Error while normalizing {path}: {ex}",
                     path=resPath, ex=e,
@@ -191,7 +191,7 @@ def upgradeCalendarCollection(calPath, directory, cuaCache):
             md5value = zlib.compress(md5value)
             try:
                 xattr.setxattr(resPath, xattrname("{http:%2F%2Ftwistedmatrix.com%2Fxml_namespace%2Fdav%2F}getcontentmd5"), md5value)
-            except IOError, ioe:
+            except IOError as ioe:
                 if ioe.errno == errno.EOPNOTSUPP:
                     # On non-native xattr systems we cannot do this,
                     # but those systems will typically not be migrating
@@ -207,7 +207,7 @@ def upgradeCalendarCollection(calPath, directory, cuaCache):
         ctagValue = zlib.compress(ctagValue)
         try:
             xattr.setxattr(calPath, xattrname("{http:%2F%2Fcalendarserver.org%2Fns%2F}getctag"), ctagValue)
-        except IOError, ioe:
+        except IOError as ioe:
             if ioe.errno == errno.EOPNOTSUPP:
                 # On non-native xattr systems we cannot do this,
                 # but those systems will typically not be migrating
@@ -251,7 +251,7 @@ def upgradeCalendarHome(homePath, directory, cuaCache):
                             if value is not None:
                                 # Need to write the xattr back to disk
                                 xattr.setxattr(calPath, attr, value)
-                except IOError, ioe:
+                except IOError as ioe:
                     if ioe.errno == errno.EOPNOTSUPP:
                         # On non-native xattr systems we cannot do this,
                         # but those systems will typically not be migrating
@@ -259,7 +259,7 @@ def upgradeCalendarHome(homePath, directory, cuaCache):
                         pass
                 except:
                     raise
-    except Exception, e:
+    except Exception as e:
         log.error("Failed to upgrade calendar home {path}: {ex}", path=homePath, ex=e)
         raise
 
@@ -305,7 +305,7 @@ def upgrade_to_1(config, directory):
                 shutil.copy2(oldDbPath, newDbPath)
                 os.remove(oldDbPath)
 
-        except Exception, e:
+        except Exception as e:
             raise UpgradeError(
                 "Upgrade Error: unable to move the old calendar user proxy database at '%s' to '%s' due to %s."
                 % (oldDbPath, newDbPath, str(e))
@@ -579,7 +579,7 @@ def upgrade_to_2(config, directory):
                     log.warn("Regular collection hidden: {path}", path=calPath)
                     os.rename(calPath, os.path.join(calHome, ".collection." + os.path.basename(calPath)))
 
-        except Exception, e:
+        except Exception as e:
             log.error("Failed to upgrade calendar home {path}: {ex}", path=calHome, ex=e)
             return succeed(False)
 
@@ -741,7 +741,7 @@ def upgradeData(config, directory):
             # Migrate locations/resources now because upgrade_to_1 depends
             # on them being in resources.xml
             yield migrateFromOD(directory)
-        except Exception, e:
+        except Exception as e:
             raise UpgradeError("Unable to migrate locations and resources from OD: %s" % (e,))
 
     docRoot = config.DocumentRoot
@@ -1239,7 +1239,7 @@ class PostDBImportStep(object):
                                         uuid,
                                         uri
                                     )
-                                except Exception, e:
+                                except Exception as e:
                                     log.error(
                                         "Error processing inbox item: {item} ({ex})",
                                         item=inboxItem, ex=e,
@@ -1257,7 +1257,7 @@ class PostDBImportStep(object):
 
             # FIXME: Some generic exception handlers to deal with unexpected errors that for some reason
             # we are not logging properly.
-            except Exception, e:
+            except Exception as e:
                 log.error("Exception during inbox item processing: {ex}", ex=e)
 
             except:

--- a/twistedcaldav/util.py
+++ b/twistedcaldav/util.py
@@ -127,14 +127,14 @@ def computeProcessCount(minimum, perCPU, perGB, cpuCount=None, memSize=None):
     if cpuCount is None:
         try:
             cpuCount = getNCPU()
-        except NotImplementedError, e:
+        except NotImplementedError as e:
             log.error("Unable to detect number of CPUs: {ex}", ex=str(e))
             return minimum
 
     if memSize is None:
         try:
             memSize = getMemorySize()
-        except NotImplementedError, e:
+        except NotImplementedError as e:
             log.error("Unable to detect amount of installed RAM: {ex}", ex=str(e))
             return minimum
 
@@ -157,7 +157,7 @@ def submodule(module, name):
 
     try:
         submodule = __import__(fullname)
-    except ImportError, e:
+    except ImportError as e:
         raise ImportError("Unable to import submodule %s from module %s: %s" % (name, module, e))
 
     for m in fullname.split(".")[1:]:

--- a/twistedcaldav/vcard.py
+++ b/twistedcaldav/vcard.py
@@ -286,7 +286,7 @@ class Component (object):
         errmsg = "Unknown"
         try:
             result = Card.parseData(data, format)
-        except ErrorBase, e:
+        except ErrorBase as e:
             errmsg = "%s: %s" % (e.mReason, e.mData,)
             result = None
         if not result:

--- a/twistedcaldav/xmlutil.py
+++ b/twistedcaldav/xmlutil.py
@@ -47,7 +47,7 @@ def readXML(xmlfile, expectedRootTag=None):
     # Read in XML
     try:
         etree = XML.ElementTree(file=xmlfile)
-    except XMLParseError, e:
+    except XMLParseError as e:
         raise ValueError("Unable to parse file '%s' because: %s" % (xmlfile, e,))
 
     if expectedRootTag:

--- a/txdav/base/datastore/subpostgres.py
+++ b/txdav/base/datastore/subpostgres.py
@@ -570,7 +570,7 @@ class PostgresService(MultiService):
             if self.uid and self.gid:
                 os.chown(self.socketDir.path, self.uid, self.gid)
 
-            os.chmod(self.socketDir.path, 0770)
+            os.chmod(self.socketDir.path, 0o770)
 
         if not self.dataStoreDirectory.isdir():
             log.info("Creating {dir}", dir=self.dataStoreDirectory.path.decode("utf-8"))

--- a/txdav/base/propertystore/appledouble_xattr.py
+++ b/txdav/base/propertystore/appledouble_xattr.py
@@ -75,7 +75,7 @@ def attrsFromFile(fileobj, debugFile=None):
         magic, version, _ignore, nentry = struct.unpack(
             AS_HEADER_FORMAT, header
         )
-    except ValueError, arg:
+    except ValueError as arg:
         raise ValueError("Unpack header error: %s" % (arg,))
     if debugFile is not None:
         debugFile.write('Magic:   0x%8.8x\n' % (magic,))
@@ -97,7 +97,7 @@ def attrsFromFile(fileobj, debugFile=None):
     for hdr in headers:
         try:
             restype, offset, length = struct.unpack(AS_ENTRY_FORMAT, hdr)
-        except ValueError, arg:
+        except ValueError as arg:
             raise ValueError("Unpack entry error: %s" % (arg,))
         if debugFile is not None:
             debugFile.write("\n-- Fork %d, offset %d, length %d\n" %

--- a/txdav/base/propertystore/test/base.py
+++ b/txdav/base/propertystore/test/base.py
@@ -42,7 +42,7 @@ class NonePropertyStoreTest(unittest.TestCase):
     def test_interface(self):
         try:
             verifyObject(IPropertyStore, self.propertyStore)
-        except BrokenMethodImplementation, e:
+        except BrokenMethodImplementation as e:
             self.fail(e)
 
     def test_delete_none(self):

--- a/txdav/base/propertystore/test/test_base.py
+++ b/txdav/base/propertystore/test/test_base.py
@@ -32,7 +32,7 @@ class PropertyNameTest(unittest.TestCase):
         name = PropertyName("http://calendarserver.org/", "bleargh")
         try:
             verifyObject(IPropertyName, name)
-        except BrokenMethodImplementation, e:
+        except BrokenMethodImplementation as e:
             self.fail(e)
 
     def test_init(self):

--- a/txdav/base/propertystore/test/test_sql.py
+++ b/txdav/base/propertystore/test/test_sql.py
@@ -33,7 +33,7 @@ from twext.enterprise.ienterprise import AlreadyFinishedError
 
 try:
     from txdav.base.propertystore.sql import PropertyStore
-except ImportError, e:
+except ImportError as e:
     # XXX: when could this ever fail?
     PropertyStore = None
     importErrorMessage = str(e)

--- a/txdav/base/propertystore/test/test_xattr.py
+++ b/txdav/base/propertystore/test/test_xattr.py
@@ -26,7 +26,7 @@ from txdav.base.propertystore.test import base
 try:
     from txdav.base.propertystore.xattr import PropertyStore
     from xattr import xattr
-except ImportError, e:
+except ImportError as e:
     PropertyStore = None
     importErrorMessage = str(e)
 

--- a/txdav/base/propertystore/xattr.py
+++ b/txdav/base/propertystore/xattr.py
@@ -158,7 +158,7 @@ class PropertyStore(AbstractPropertyStore):
         try:
             try:
                 data = self.attrs[self._encodeKey(effectiveKey)]
-            except IOError, e:
+            except IOError as e:
                 if e.errno in [_ERRNO_NO_ATTR, errno.ENOENT]:
                     raise KeyError(key)
                 raise PropertyStoreError(e)
@@ -168,7 +168,7 @@ class PropertyStore(AbstractPropertyStore):
                 try:
                     data = self.attrs[self._encodeKey(effectiveKey,
                                                       compressNamespace=False)]
-                except IOError, e:
+                except IOError as e:
                     raise KeyError(key)
 
                 try:
@@ -176,7 +176,7 @@ class PropertyStore(AbstractPropertyStore):
                     self.attrs[self._encodeKey(effectiveKey)] = data
                     del self.attrs[self._encodeKey(effectiveKey,
                                                    compressNamespace=False)]
-                except IOError, e:
+                except IOError as e:
                     msg = (
                         "Unable to upgrade property "
                         "to compressed namespace: %s" % (key.toString())
@@ -249,7 +249,7 @@ class PropertyStore(AbstractPropertyStore):
 
         try:
             iterattr = iter(self.attrs)
-        except IOError, e:
+        except IOError as e:
             if e.errno != errno.ENOENT:
                 raise
             iterattr = iter(())
@@ -297,7 +297,7 @@ class PropertyStore(AbstractPropertyStore):
                 del attrs[self._encodeKey(key)]
             except KeyError:
                 pass
-            except IOError, e:
+            except IOError as e:
                 if e.errno != _ERRNO_NO_ATTR:
                     raise
 
@@ -320,7 +320,7 @@ class PropertyStore(AbstractPropertyStore):
         """
         try:
             iterattr = iter(other.attrs)
-        except IOError, e:
+        except IOError as e:
             if e.errno != errno.ENOENT:
                 raise
             iterattr = iter(())

--- a/txdav/caldav/datastore/file.py
+++ b/txdav/caldav/datastore/file.py
@@ -444,7 +444,7 @@ class CalendarObject(CommonObjectResource, CalendarObjectBase):
         text = self._text()
         try:
             component = VComponent.fromString(text)
-        except InvalidICalendarDataError, e:
+        except InvalidICalendarDataError as e:
             # This is a really bad situation, so do raise
             raise InternalDataStoreError(
                 "File corruption detected (%s) in file: %s"
@@ -483,7 +483,7 @@ class CalendarObject(CommonObjectResource, CalendarObjectBase):
 
         try:
             fh = self._path.open()
-        except IOError, e:
+        except IOError as e:
             if e[0] == ENOENT:
                 raise ConcurrentModification()
             else:

--- a/txdav/caldav/datastore/index_file.py
+++ b/txdav/caldav/datastore/index_file.py
@@ -707,7 +707,7 @@ class CalendarIndex (AbstractCalendarIndex):
         try:
             instances = calendar.expandTimeRanges(expand, ignoreInvalidInstances=reCreate)
             recurrenceLimit = instances.limit
-        except InvalidOverriddenInstanceError, e:
+        except InvalidOverriddenInstanceError as e:
             log.error("Invalid instance {rid} when indexing {name} in {rsrc!r}", rid=e.rid, name=name, rsrc=self.resource)
             raise
 
@@ -887,7 +887,8 @@ class MemcachedUIDReserver(CachePoolUserMixIn):
             uid=uid, path=self.index.resource.fp.path,
         )
 
-        def _checkValue((flags, value)):
+        def _checkValue(xxx_todo_changeme):
+            (flags, value) = xxx_todo_changeme
             if value is None:
                 return False
             else:
@@ -920,7 +921,7 @@ class SQLUIDReserver(object):
                 "UID %s already reserved for calendar collection %s."
                 % (uid, self.index.resource)
             )
-        except sqlite.Error, e:
+        except sqlite.Error as e:
             log.error("Unable to reserve UID: {ex}", ex=e)
             self.index._db_rollback()
             raise
@@ -943,7 +944,7 @@ class SQLUIDReserver(object):
                     self.index._db_execute(
                         "delete from RESERVED where UID = :1", uid)
                     self.index._db_commit()
-                except sqlite.Error, e:
+                except sqlite.Error as e:
                     log.error("Unable to unreserve UID: {ex}", ex=e)
                     self.index._db_rollback()
                     raise
@@ -970,7 +971,7 @@ class SQLUIDReserver(object):
                 try:
                     self.index._db_execute("delete from RESERVED where UID = :1", uid)
                     self.index._db_commit()
-                except sqlite.Error, e:
+                except sqlite.Error as e:
                     log.error("Unable to unreserve UID: {ex}", ex=e)
                     self.index._db_rollback()
                     raise
@@ -1066,7 +1067,7 @@ class Index (CalendarIndex):
                 continue
             try:
                 stream = child.open()
-            except (IOError, OSError), e:
+            except (IOError, OSError) as e:
                 log.error("Unable to open resource {name}: {ex}", name=name, ex=e)
                 continue
 
@@ -1174,7 +1175,7 @@ class IndexSchedule (CalendarIndex):
                 continue
             try:
                 stream = child.open()
-            except (IOError, OSError), e:
+            except (IOError, OSError) as e:
                 log.error("Unable to open resource {name}: {ex}", name=name, ex=e)
                 continue
 

--- a/txdav/caldav/datastore/scheduling/imip/delivery.py
+++ b/txdav/caldav/datastore/scheduling/imip/delivery.py
@@ -120,7 +120,7 @@ class ScheduleViaIMip(DeliveryService):
                         enqueueOp
                     )
 
-                except Exception, e:
+                except Exception as e:
                     # Generated failed response for this recipient
                     log.debug(
                         "iMIP request {req} failed for recipient {r}: {exc}",
@@ -137,7 +137,7 @@ class ScheduleViaIMip(DeliveryService):
                         reqstatus=iTIPRequestStatus.MESSAGE_SENT
                     )
 
-        except Exception, e:
+        except Exception as e:
             # Generated failed responses for each recipient
             log.debug("iMIP request {req} failed: {exc}", req=self, exc=e)
             for recipient in self.recipients:

--- a/txdav/caldav/datastore/scheduling/imip/inbound.py
+++ b/txdav/caldav/datastore/scheduling/imip/inbound.py
@@ -393,7 +393,7 @@ class MailReceiver(object):
             if dateString is not None:
                 try:
                     dateSent = dateutil.parser.parse(dateString)
-                except Exception, e:
+                except Exception as e:
                     log.info(
                         "Could not parse date in IMIP email '{date}' ({ex})",
                         date=dateString, ex=e,
@@ -537,7 +537,7 @@ class MailReceiver(object):
 
             return self.processReply(msg)
 
-        except Exception, e:
+        except Exception as e:
             # Don't let a failure of any kind stop us
             log.error("Failed to process message: {error}", error=str(e))
         return succeed(self.UNKNOWN_FAILURE)
@@ -550,7 +550,7 @@ def injectMessage(txn, organizer, attendee, calendar):
         scheduler = IMIPScheduler(txn, None)
         results = (yield scheduler.doSchedulingDirectly("iMIP", attendee, [organizer, ], calendar,))
         log.info("Successfully injected iMIP response from {attendee} to {organizer}", attendee=attendee, organizer=organizer)
-    except Exception, e:
+    except Exception as e:
         log.error("Failed to inject iMIP response ({error})", error=str(e))
         raise
 

--- a/txdav/caldav/datastore/scheduling/imip/outbound.py
+++ b/txdav/caldav/datastore/scheduling/imip/outbound.py
@@ -485,7 +485,7 @@ class MailSender(object):
             success = (yield self.smtpSender.sendMessage(
                 fromAddr, toAddr, msgId, message))
             returnValue(success)
-        except Exception, e:
+        except Exception as e:
             self.log.error("Failed to send IMIP message ({ex})", ex=str(e))
             returnValue(False)
 
@@ -604,7 +604,7 @@ class MailSender(object):
 
         return msgId, msg.as_string()
 
-    def renderPlainText(self, details, (orgCN, orgEmail), attendees, canceled):
+    def renderPlainText(self, details, xxx_todo_changeme, attendees, canceled):
         """
         Render text/plain message part based on invitation details and a flag
         indicating whether the message is a cancellation.
@@ -613,6 +613,7 @@ class MailSender(object):
 
         @rtype: C{str}
         """
+        (orgCN, orgEmail) = xxx_todo_changeme
         plainAttendeeList = []
         for cn, mailto in attendees:
             if cn:

--- a/txdav/caldav/datastore/scheduling/ischedule/delivery.py
+++ b/txdav/caldav/datastore/scheduling/ischedule/delivery.py
@@ -256,7 +256,7 @@ class IScheduleRequest(object):
             else:
                 raise ValueError("Incorrect server response status code: {code}".format(code=response.code))
 
-        except Exception, e:
+        except Exception as e:
             # Check for connection failure
             if isinstance(e, MultiFailure) and not self.scheduler.isfreebusy:
                 all_connections_failed = all([isinstance(err.value, ConnectionRefusedError) for err in e.failures])

--- a/txdav/caldav/datastore/scheduling/ischedule/dkim.py
+++ b/txdav/caldav/datastore/scheduling/ischedule/dkim.py
@@ -89,7 +89,7 @@ class DKIMUtils(object):
             try:
                 with open(config.Scheduling.iSchedule.DKIM.PrivateKeyFile) as f:
                     key_data = f.read()
-            except IOError, e:
+            except IOError as e:
                 msg = "DKIM: Cannot read private key file: %s %s" % (config.Scheduling.iSchedule.DKIM.PrivateKeyFile, e,)
                 log.error(msg)
                 raise ConfigurationError(msg)
@@ -103,7 +103,7 @@ class DKIMUtils(object):
             try:
                 with open(config.Scheduling.iSchedule.DKIM.PublicKeyFile) as f:
                     key_data = f.read()
-            except IOError, e:
+            except IOError as e:
                 msg = "DKIM: Cannot read public key file: %s %s" % (config.Scheduling.iSchedule.DKIM.PublicKeyFile, e,)
                 log.error(msg)
                 raise ConfigurationError(msg)
@@ -118,7 +118,7 @@ class DKIMUtils(object):
                 if not os.path.exists(config.Scheduling.iSchedule.DKIM.PrivateExchanges):
                     try:
                         os.makedirs(config.Scheduling.iSchedule.DKIM.PrivateExchanges)
-                    except IOError, e:
+                    except IOError as e:
                         msg = "DKIM: Cannot create public key private exchange directory: %s" % (config.Scheduling.iSchedule.DKIM.PrivateExchanges,)
                         log.error(msg)
                         raise ConfigurationError(msg)
@@ -911,7 +911,7 @@ class PublicKeyLookup_PrivateExchange(PublicKeyLookup):
         try:
             with open(keyfile) as f:
                 keys = f.read()
-        except IOError, e:
+        except IOError as e:
             log.debug("DKIM: Failed private-exchange lookup: could not read {path} {ex}", path=keyfile, ex=e)
             return succeed(())
 
@@ -944,7 +944,7 @@ class DomainKeyResource (SimpleResource):
         try:
             with open(pubkeyfile) as f:
                 key_data = f.read()
-        except IOError, e:
+        except IOError as e:
             log.error("DKIM: Unable to open the public key file: {path} because of {ex}", path=pubkeyfile, ex=e)
             raise
 

--- a/txdav/caldav/datastore/scheduling/ischedule/localservers.py
+++ b/txdav/caldav/datastore/scheduling/ischedule/localservers.py
@@ -160,7 +160,7 @@ class Server(object):
         # Need to cache IP addresses
         try:
             ips = getIPsFromHost(parsed_uri.hostname)
-        except socket.gaierror, e:
+        except socket.gaierror as e:
             msg = "Unable to lookup ip-addr for server '{}': {}".format(parsed_uri.hostname, str(e))
             log.error(msg)
             if ignoreIPLookupFailures:
@@ -174,7 +174,7 @@ class Server(object):
             if not isIPAddress(item) and not isIPv6Address(item):
                 try:
                     ips = getIPsFromHost(item)
-                except socket.gaierror, e:
+                except socket.gaierror as e:
                     msg = "Unable to lookup ip-addr for allowed-from '{}': {}".format(item, str(e))
                     log.error(msg)
                     if not ignoreIPLookupFailures:
@@ -273,7 +273,7 @@ class ServersParser(object):
         # Read in XML
         try:
             _ignore_tree, servers_node = readXML(xmlFile, ELEMENT_SERVERS)
-        except ValueError, e:
+        except ValueError as e:
             raise RuntimeError("XML parse error for '{}' because: {}".format(xmlFile, e,))
 
         for child in servers_node:

--- a/txdav/caldav/datastore/scheduling/ischedule/scheduler.py
+++ b/txdav/caldav/datastore/scheduling/ischedule/scheduler.py
@@ -164,7 +164,7 @@ class IScheduleScheduler(RemoteScheduler):
                 # when DKIM is not enabled, so that any local policy via remoteservers.xml can be used.
                 pass
 
-            except DKIMVerificationError, e:
+            except DKIMVerificationError as e:
                 # If DKIM is enabled and there was a DKIM header present, then fail
                 msg = "Failed to verify DKIM signature"
                 _debug_msg = str(e)
@@ -335,7 +335,7 @@ class IScheduleScheduler(RemoteScheduler):
                         else:
                             continue
                         break
-                except socket.herror, e:
+                except socket.herror as e:
                     log.debug(
                         "iSchedule cannot lookup client ip '{ip}': {exc}",
                         ip=clientip,
@@ -393,7 +393,7 @@ class IScheduleScheduler(RemoteScheduler):
                     if ip == clientip:
                         matched = True
                         break
-            except socket.herror, e:
+            except socket.herror as e:
                 log.debug(
                     "iSchedule cannot lookup client ip '{ip}': {exc}",
                     ip=clientip,

--- a/txdav/caldav/datastore/scheduling/ischedule/test/test_dkim.py
+++ b/txdav/caldav/datastore/scheduling/ischedule/test/test_dkim.py
@@ -497,7 +497,7 @@ Connection:close
                 TestPublicKeyLookup.PublicKeyLookup_Testing.flushCache()
                 try:
                     yield verifier.verify()
-                except Exception, e:
+                except Exception as e:
                     if result:
                         self.fail("DKIMVerifier:verify failed: %s" % (e,))
                 else:

--- a/txdav/caldav/datastore/scheduling/ischedule/utils.py
+++ b/txdav/caldav/datastore/scheduling/ischedule/utils.py
@@ -61,7 +61,7 @@ def lookupServerViaSRV(domain, service="_ischedules"):
     log.debug("DNS SRV: lookup: {l}", l=lookup)
     try:
         answers = (yield DebugResolver.lookupService(lookup))[0]
-    except (DomainError, AuthoritativeDomainError), e:
+    except (DomainError, AuthoritativeDomainError) as e:
         log.debug("DNS SRV: lookup failed: {exc}", exc=e)
         returnValue(None)
 
@@ -123,7 +123,7 @@ def lookupDataViaTXT(domain, prefix=""):
     log.debug("DNS TXT: lookup: {l}", l=lookup)
     try:
         answers = (yield DebugResolver.lookupText(lookup))[0]
-    except (DomainError, AuthoritativeDomainError), e:
+    except (DomainError, AuthoritativeDomainError) as e:
         log.debug("DNS TXT: lookup failed: {exc}", exc=e)
         answers = ()
 

--- a/txdav/caldav/datastore/scheduling/processing.py
+++ b/txdav/caldav/datastore/scheduling/processing.py
@@ -113,7 +113,7 @@ class ImplicitProcessor(object):
             except ImplicitProcessorException:
                 # These we always pass up
                 raise
-            except Exception, e:
+            except Exception as e:
                 # We attempt to recover from this. That involves trying to re-write the attendee data
                 # to match that of the organizer assuming we have the organizer's full data available, then
                 # we try the processing operation again.
@@ -124,7 +124,7 @@ class ImplicitProcessor(object):
                     log.error("ImplicitProcessing - originator '{orig}' to recipient '{recip}' with UID: '{uid}' - restored organizer's copy", orig=self.originator.cuaddr, recip=self.recipient.cuaddr, uid=self.uid)
                     try:
                         result = (yield self.doImplicitAttendee())
-                    except Exception, e:
+                    except Exception as e:
                         log.failure("{processor}.doImplicitAttendee()", processor=self)
                         log.error("ImplicitProcessing - originator '{orig}' to recipient '{recip}' with UID: '{uid}' - exception raised after fix: {ex}", orig=self.originator.cuaddr, recip=self.recipient.cuaddr, uid=self.uid, ex=e)
                         raise ImplicitProcessorException("5.1;Service unavailable")

--- a/txdav/caldav/datastore/scheduling/scheduler.py
+++ b/txdav/caldav/datastore/scheduling/scheduler.py
@@ -273,7 +273,7 @@ class Scheduler(object):
             # Must be a valid calendar
             try:
                 self.calendar.validCalendarData()
-            except ValueError, e:
+            except ValueError as e:
                 log.error(
                     "{method} request calendar component is not valid:{exc} {cal}",
                     method=self.method,

--- a/txdav/caldav/datastore/scheduling/test/test_implicit.py
+++ b/txdav/caldav/datastore/scheduling/test/test_implicit.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 ##
 # Copyright (c) 2005-2017 Apple Inc. All rights reserved.
 #
@@ -1054,7 +1055,7 @@ END:VCALENDAR
         try:
             doAction, isScheduleObject = (yield scheduler.testImplicitSchedulingPUT(calendar_collection, calresource, calendarNew, False))
         except Exception as e:
-            print e
+            print(e)
             self.fail("Exception must not be raised")
         self.assertTrue(doAction)
         self.assertTrue(isScheduleObject)

--- a/txdav/caldav/datastore/scheduling/work.py
+++ b/txdav/caldav/datastore/scheduling/work.py
@@ -443,7 +443,7 @@ class ScheduleOrganizerWork(ScheduleWorkMixin, fromTable(schema.SCHEDULE_ORGANIZ
 
             self._dequeued()
 
-        except Exception, e:
+        except Exception as e:
             log.debug("ScheduleOrganizerWork - exception ID: {id}, UID: '{uid}', {err}", id=self.workID, uid=self.icalendarUID, err=str(e))
             log.debug(traceback.format_exc())
             raise
@@ -592,7 +592,7 @@ class ScheduleOrganizerSendWork(ScheduleWorkMixin, fromTable(schema.SCHEDULE_ORG
 
             self._dequeued()
 
-        except Exception, e:
+        except Exception as e:
             log.debug("ScheduleOrganizerSendWork - exception ID: {id}, UID: '{uid}', {err}", id=self.workID, uid=self.icalendarUID, err=str(e))
             log.debug(traceback.format_exc())
             raise
@@ -710,7 +710,7 @@ class ScheduleReplyWork(ScheduleWorkMixin, fromTable(schema.SCHEDULE_REPLY_WORK)
 
             self._dequeued()
 
-        except Exception, e:
+        except Exception as e:
             # FIXME: calendar may not be set here!
             log.debug("ScheduleReplyWork - exception ID: {id}, UID: '{uid}', {err}", id=self.workID, uid=itipmsg.resourceUID(), err=str(e))
             raise
@@ -901,7 +901,7 @@ class ScheduleRefreshWork(ScheduleWorkMixin, fromTable(schema.SCHEDULE_REFRESH_W
                 yield NamedLock.acquire(self.transaction, "ImplicitUIDLock:%s" % (hashlib.md5(organizer_resource.uid()).hexdigest(),))
 
                 yield self._doRefresh(organizer_resource, attendeesToProcess)
-            except Exception, e:
+            except Exception as e:
                 log.debug("ImplicitProcessing - refresh exception UID: '{uid}', {exc}", uid=organizer_resource.uid(), exc=str(e))
                 raise
             except:
@@ -1061,7 +1061,7 @@ class ScheduleAutoReplyWork(ScheduleWorkMixin, fromTable(schema.SCHEDULE_AUTO_RE
                 from txdav.caldav.datastore.scheduling.implicit import ImplicitScheduler
                 scheduler = ImplicitScheduler()
                 yield scheduler.sendAttendeeReply(self.transaction, resource)
-            except Exception, e:
+            except Exception as e:
                 log.debug("ImplicitProcessing - auto-reply exception UID: '{uid}', {ex}", uid=resource.uid(), ex=str(e))
                 raise
             except:

--- a/txdav/caldav/datastore/sql.py
+++ b/txdav/caldav/datastore/sql.py
@@ -195,7 +195,7 @@ class CalendarStoreFeatures(object):
             total = len(rows)
             count = 0
             log.warn("{total} dropbox ids to migrate", total=total)
-        except RuntimeError, e:
+        except RuntimeError as e:
             log.error("Dropbox migration failed when cleaning out dropbox ids: {ex}", ex=e)
             yield txn.abort()
             raise
@@ -220,7 +220,7 @@ class CalendarStoreFeatures(object):
                         (yield self._upgradeDropbox(txn, dropbox_id))
                     count += len(rows)
                     log.warn("{count} of {total} dropbox ids migrated", count=count, total=total)
-            except RuntimeError, e:
+            except RuntimeError as e:
                 log.error("Dropbox migration failed for '{id}': {ex}", id=dropbox_id, ex=e)
                 yield txn.abort()
                 raise
@@ -2967,7 +2967,7 @@ class CalendarObject(CommonObjectResource, CalendarObjectBase):
         try:
             if self._txn._migrating:
                 component.validOrganizerForScheduling(doFix=True)
-        except InvalidICalendarDataError, e:
+        except InvalidICalendarDataError as e:
             raise ValidOrganizerError(str(e))
 
     @inlineCallbacks
@@ -3926,7 +3926,7 @@ class CalendarObject(CommonObjectResource, CalendarObjectBase):
                 instances = component.expandTimeRanges(expand, lowerLimit=truncateLowerLimit, ignoreInvalidInstances=reCreate)
                 recurrenceLimit = instances.limit
                 recurrenceLowerLimit = instances.lowerLimit
-            except InvalidOverriddenInstanceError, e:
+            except InvalidOverriddenInstanceError as e:
                 self.log.error(
                     "Invalid instance {rid} when indexing {name} in {cal!r}",
                     rid=e.rid, name=self._name, cal=self._calendar,
@@ -4188,7 +4188,7 @@ class CalendarObject(CommonObjectResource, CalendarObjectBase):
 
             try:
                 component = Component.fromString(text)
-            except InvalidICalendarDataError, e:
+            except InvalidICalendarDataError as e:
                 # This is a really bad situation, so do raise
                 raise InternalDataStoreError(
                     "Data corruption detected ({0}) in id: {1}".format(
@@ -4768,7 +4768,7 @@ class CalendarObject(CommonObjectResource, CalendarObjectBase):
             attachment = (yield self.createManagedAttachment())
             t = attachment.store(content_type, filename)
             yield readStream(stream, t.write)
-        except Exception, e:
+        except Exception as e:
             self.log.error("Unable to store attachment: {ex}", ex=e)
             raise AttachmentStoreFailed
         yield t.loseConnection()
@@ -4838,7 +4838,7 @@ class CalendarObject(CommonObjectResource, CalendarObjectBase):
             attachment = (yield self.updateManagedAttachment(managed_id, oldattachment))
             t = attachment.store(content_type, filename)
             yield readStream(stream, t.write)
-        except Exception, e:
+        except Exception as e:
             self.log.error("Unable to store attachment: {ex}", ex=e)
             raise AttachmentStoreFailed
         yield t.loseConnection()

--- a/txdav/caldav/datastore/sql_attachment.py
+++ b/txdav/caldav/datastore/sql_attachment.py
@@ -634,9 +634,9 @@ class DropBoxAttachment(Attachment):
         }, Return=(att.ATTACHMENT_ID, att.CREATED, att.MODIFIED)).on(txn))
 
         row_iter = iter(rows[0])
-        a_id = row_iter.next()
-        created = parseSQLTimestamp(row_iter.next())
-        modified = parseSQLTimestamp(row_iter.next())
+        a_id = next(row_iter)
+        created = parseSQLTimestamp(next(row_iter))
+        modified = parseSQLTimestamp(next(row_iter))
 
         attachment = cls(txn, a_id, dropboxID, name, ownerHomeID, True)
         attachment._created = created
@@ -793,9 +793,9 @@ class ManagedAttachment(Attachment):
         }, Return=(att.ATTACHMENT_ID, att.CREATED, att.MODIFIED)).on(txn))
 
         row_iter = iter(rows[0])
-        a_id = row_iter.next()
-        created = parseSQLTimestamp(row_iter.next())
-        modified = parseSQLTimestamp(row_iter.next())
+        a_id = next(row_iter)
+        created = parseSQLTimestamp(next(row_iter))
+        modified = parseSQLTimestamp(next(row_iter))
 
         attachment = cls(txn, a_id, ".", None, ownerHomeID, True)
         attachment._managedID = managedID

--- a/txdav/caldav/datastore/test/test_index_file.py
+++ b/txdav/caldav/datastore/test/test_index_file.py
@@ -52,7 +52,7 @@ class MinimalCalendarObjectReplacement(object):
             # Fix any bogus data we can
             component.validCalendarData()
             component.validCalendarForCalDAV(methodAllowed=False)
-        except InvalidICalendarDataError, e:
+        except InvalidICalendarDataError as e:
             raise InternalDataStoreError(
                 "File corruption detected (%s) in file: %s"
                 % (e, self._path.path)

--- a/txdav/caldav/datastore/util.py
+++ b/txdav/caldav/datastore/util.py
@@ -96,7 +96,7 @@ def validateCalendarComponent(calendarObject, calendar, component, inserting, mi
         component.validCalendarForCalDAV(methodAllowed=calendar.name() == 'inbox')
         if migrating:
             component.validOrganizerForScheduling(doFix=True)
-    except InvalidICalendarDataError, e:
+    except InvalidICalendarDataError as e:
         raise InvalidObjectResourceError(e)
 
 
@@ -110,7 +110,7 @@ def normalizationLookup(cuaddr, recordFunction, config):
     """
     try:
         record = yield recordFunction(cuaddr)
-    except Exception, e:
+    except Exception as e:
         log.debug("Lookup of {cuaddr} failed: {ex}", cuaddr=cuaddr, ex=e)
         record = None
 
@@ -201,7 +201,7 @@ def _migrateCalendar(inCalendar, outCalendar, getComponent, merge=False):
     for calendarObject in (yield inCalendar.calendarObjects()):
         try:
             ctype = yield calendarObject.componentType()
-        except Exception, e:  # Don't stop for any error
+        except Exception as e:  # Don't stop for any error
             log.error(
                 "  Failed to migrate calendar object: {home}/{cal}/{rsrc} (ex)",
                 home=inCalendar.ownerHome().name(),
@@ -273,7 +273,7 @@ def _migrateCalendar(inCalendar, outCalendar, getComponent, merge=False):
             )
             bad_count += 1
 
-        except Exception, e:
+        except Exception as e:
             log.error(
                 "  {ex}: Failed to migrate calendar object: {home}/{cal}/{rsrc}",
                 ex=str(e),

--- a/txdav/carddav/datastore/file.py
+++ b/txdav/carddav/datastore/file.py
@@ -219,7 +219,7 @@ class AddressBookObject(CommonObjectResource):
         text = self._text()
         try:
             component = VComponent.fromString(text)
-        except InvalidVCardDataError, e:
+        except InvalidVCardDataError as e:
             # This is a really bad situation, so do raise
             raise InternalDataStoreError(
                 "File corruption detected (%s) in file: %s"
@@ -243,7 +243,7 @@ class AddressBookObject(CommonObjectResource):
 
         try:
             fh = self._path.open()
-        except IOError, e:
+        except IOError as e:
             if e[0] == ENOENT:
                 raise NoSuchObjectResourceError(self)
             else:

--- a/txdav/carddav/datastore/index_file.py
+++ b/txdav/carddav/datastore/index_file.py
@@ -121,7 +121,8 @@ class MemcachedUIDReserver(CachePoolUserMixIn):
             uid=uid, path=self.index.resource.fp.path,
         )
 
-        def _checkValue((flags, value)):
+        def _checkValue(xxx_todo_changeme):
+            (flags, value) = xxx_todo_changeme
             if value is None:
                 return False
             else:
@@ -154,7 +155,7 @@ class SQLUIDReserver(object):
                 "UID %s already reserved for address book collection %s."
                 % (uid, self.index.resource)
             )
-        except sqlite.Error, e:
+        except sqlite.Error as e:
             log.error("Unable to reserve UID: {ex}", ex=e)
             self.index._db_rollback()
             raise
@@ -177,7 +178,7 @@ class SQLUIDReserver(object):
                     self.index._db_execute(
                         "delete from RESERVED where UID = :1", uid)
                     self.index._db_commit()
-                except sqlite.Error, e:
+                except sqlite.Error as e:
                     log.error("Unable to unreserve UID: {ex}", ex=e)
                     self.index._db_rollback()
                     raise
@@ -204,7 +205,7 @@ class SQLUIDReserver(object):
                 try:
                     self.index._db_execute("delete from RESERVED where UID = :1", uid)
                     self.index._db_commit()
-                except sqlite.Error, e:
+                except sqlite.Error as e:
                     log.error("Unable to unreserve UID: {ex}", ex=e)
                     self.index._db_rollback()
                     raise
@@ -614,7 +615,7 @@ class AddressBookIndex(AbstractSQLDatabase):
                 continue
             try:
                 stream = child.open()
-            except (IOError, OSError), e:
+            except (IOError, OSError) as e:
                 log.error("Unable to open resource {name}: {ex}", name=name, ex=e)
                 continue
 

--- a/txdav/carddav/datastore/sql.py
+++ b/txdav/carddav/datastore/sql.py
@@ -2280,11 +2280,11 @@ class AddressBookObject(CommonObjectResource, AddressBookObjectSharingMixIn):
 
         try:
             component.validVCardData()
-        except InvalidVCardDataError, e:
+        except InvalidVCardDataError as e:
             raise InvalidObjectResourceError(str(e))
         try:
             component.validForCardDAV()
-        except InvalidVCardDataError, e:
+        except InvalidVCardDataError as e:
             raise InvalidComponentForStoreError(str(e))
 
     def _componentResourceKindToKind(self, component):
@@ -2631,7 +2631,7 @@ class AddressBookObject(CommonObjectResource, AddressBookObjectSharingMixIn):
 
                 try:
                     component = VCard.fromString(text)
-                except InvalidVCardDataError, e:
+                except InvalidVCardDataError as e:
                     # This is a really bad situation, so do raise
                     raise InternalDataStoreError(
                         "Data corruption detected (%s) in id: %s"

--- a/txdav/carddav/datastore/test/common.py
+++ b/txdav/carddav/datastore/test/common.py
@@ -325,7 +325,7 @@ class CommonTests(CommonCommonTests):
         addressbook = yield home.addressbookWithName("addressbook")
         try:
             yield addressbook.rename("some-other-name")
-        except HTTPError, e:
+        except HTTPError as e:
             self.assertEquals(e.response.code, FORBIDDEN)
 
     @inlineCallbacks

--- a/txdav/carddav/datastore/util.py
+++ b/txdav/carddav/datastore/util.py
@@ -60,7 +60,7 @@ def validateAddressBookComponent(addressbookObject, vcard, component, inserting)
     try:
         component.validVCardData()
         component.validForCardDAV()
-    except InvalidVCardDataError, e:
+    except InvalidVCardDataError as e:
         raise InvalidObjectResourceError(e)
 
 
@@ -108,7 +108,7 @@ def _migrateAddressbook(inAddressbook, outAddressbook, getComponent):
             )
             bad_count += 1
 
-        except Exception, e:
+        except Exception as e:
             log.error(
                 "  {ex}: Failed to migrate address book object: {home}/{adbk}/{rsrc}",
                 ex=str(e),

--- a/txdav/common/datastore/file.py
+++ b/txdav/common/datastore/file.py
@@ -210,7 +210,7 @@ class CommonDataStore(DataStore):
             except:
                 a, b, c = sys.exc_info()
                 yield txn.abort()
-                raise a, b, c
+                raise a(b, c)
             else:
                 yield txn.commit()
 
@@ -615,7 +615,7 @@ class CommonHome(FileMetaDataMixin):
         def createDirectory(path):
             try:
                 path.createDirectory()
-            except (IOError, OSError), e:
+            except (IOError, OSError) as e:
                 if e.errno != EEXIST:
                     # Ignore, in case someone else created the
                     # directory while we were trying to as well.
@@ -767,7 +767,7 @@ class CommonHome(FileMetaDataMixin):
                 c._name = name
                 # FIXME: _lots_ of duplication of work here.
                 props.flush()
-            except (IOError, OSError), e:
+            except (IOError, OSError) as e:
                 if e.errno == EEXIST and childPath.isdir():
                     raise HomeChildNameAlreadyExistsError(name)
                 raise
@@ -1031,7 +1031,7 @@ class CommonHomeChild(FileMetaDataMixin, FancyEqMixin, HomeChildBase):
 
             try:
                 childPath.moveTo(trash)
-            except (IOError, OSError), e:
+            except (IOError, OSError) as e:
                 if e.errno == ENOENT:
                     raise NoSuchHomeChildError(self._name)
                 raise
@@ -1041,7 +1041,7 @@ class CommonHomeChild(FileMetaDataMixin, FancyEqMixin, HomeChildBase):
                     self.retrieveOldIndex()._db_close()  # Must close sqlite file before it is deleted
                     trash.remove()
                     self.properties()._removeResource()
-                except Exception, e:
+                except Exception as e:
                     self.log.error("Unable to delete trashed child at {path}: {ex}", path=trash.fp, ex=e)
 
             self._transaction.addOperation(cleanup, "remove child backup %r" % (self._name,))
@@ -1399,7 +1399,7 @@ class NotificationCollection(CommonHomeChild):
                 c._name = collectionName
                 # FIXME: _lots_ of duplication of work here.
                 props.flush()
-            except (IOError, OSError), e:
+            except (IOError, OSError) as e:
                 if e.errno == EEXIST and childPath.isdir():
                     raise HomeChildNameAlreadyExistsError(collectionName)
                 raise
@@ -1542,7 +1542,7 @@ class NotificationObject(CommonObjectResource):
             return self._notificationdata
         try:
             fh = self._path.open()
-        except IOError, e:
+        except IOError as e:
             if e[0] == ENOENT:
                 raise NoSuchObjectResourceError(self)
             else:

--- a/txdav/common/datastore/sql.py
+++ b/txdav/common/datastore/sql.py
@@ -18,6 +18,7 @@
 """
 SQL data store.
 """
+from __future__ import print_function
 
 __all__ = [
     "CommonDataStore",
@@ -235,7 +236,7 @@ class CommonDataStore(Service, object):
         except:
             a, b, c = sys.exc_info()
             yield txn.abort()
-            raise a, b, c
+            raise a(b, c)
         else:
             yield txn.commit()
 
@@ -1007,7 +1008,7 @@ class CommonStoreTransaction(
             if not stmt.startswith("--"):
                 try:
                     yield self.execSQL(stmt)
-                except (RuntimeError, StandardError) as e:
+                except (RuntimeError, Exception) as e:
                     e.stmt = "SQLBlock statement failed: {}".format(stmt)
                     raise
 

--- a/txdav/common/datastore/sql_tables.py
+++ b/txdav/common/datastore/sql_tables.py
@@ -18,6 +18,7 @@
 """
 SQL Table definitions.
 """
+from __future__ import print_function
 
 from twisted.python.modules import getModule
 from twext.enterprise.dal.syntax import SchemaSyntax, QueryGenerator
@@ -444,13 +445,13 @@ if __name__ == '__main__':
     version = sys.argv[1] if len(sys.argv) == 2 else None
     current, extras, out = _schemaFiles(version)
 
-    print "Reading from {}".format(current.path)
-    print "Extras from  {}".format(extras.path) if extras.exists() else "No extras"
-    print "Writing to   {}".format(out.path)
+    print("Reading from {}".format(current.path))
+    print("Extras from  {}".format(extras.path) if extras.exists() else "No extras")
+    print("Writing to   {}".format(out.path))
 
     with out.open("w") as outfd:
         schema = _populateSchema(current)
         _translateSchema(outfd, schema=schema)
         _schemaExtras(outfd, extras)
 
-    print "Done"
+    print("Done")

--- a/txdav/common/datastore/test/test_sql_tables.py
+++ b/txdav/common/datastore/test/test_sql_tables.py
@@ -268,7 +268,7 @@ class SQLSplitterTests(TestCase):
         A single sql statement yields a single string
         """
         result = splitSQLString("select * from foo;")
-        r1 = result.next()
+        r1 = next(result)
         self.assertEquals(r1, "select * from foo")
         self.assertRaises(StopIteration, result.next)
 
@@ -277,9 +277,9 @@ class SQLSplitterTests(TestCase):
         Two simple sql statements yield two separate strings
         """
         result = splitSQLString("select count(*) from baz; select bang from boop;")
-        r1 = result.next()
+        r1 = next(result)
         self.assertEquals(r1, "select count(*) from baz")
-        r2 = result.next()
+        r2 = next(result)
         self.assertEquals(r2, "select bang from boop")
         self.assertRaises(StopIteration, result.next)
 
@@ -309,7 +309,7 @@ class SQLSplitterTests(TestCase):
                     ) AND
                     I.EMISSION BETWEEN DATE1 AND DATE2;''')
         result = splitSQLString(bigSQL)
-        r1 = result.next()
+        r1 = next(result)
         self.assertEquals(r1, bigSQL.rstrip(";"))
         self.assertRaises(StopIteration, result.next)
 
@@ -327,7 +327,7 @@ class SQLSplitterTests(TestCase):
                END;''')
         s1 = 'BEGIN\nLOOP\nINSERT INTO T1 VALUES(i,i);i := i+1;EXIT WHEN i>100;END LOOP;END;'
         result = splitSQLString(plsql)
-        r1 = result.next()
+        r1 = next(result)
         self.assertEquals(r1, s1)
         self.assertRaises(StopIteration, result.next)
 
@@ -355,9 +355,9 @@ class SQLSplitterTests(TestCase):
                END;''')
         s2 = "BEGIN\nFOR i IN 1..10 LOOP\nIF MOD(i,2) = 0 THEN\nINSERT INTO temp VALUES (i, x, 'i is even');ELSE\nINSERT INTO temp VALUES (i, x, 'i is odd');END IF;x := x + 100;END LOOP;COMMIT;END;"
         result = splitSQLString(sql + plsql)
-        r1 = result.next()
+        r1 = next(result)
         self.assertEquals(r1, sql.rstrip(";"))
-        r2 = result.next()
+        r2 = next(result)
         self.assertEquals(r2, s2)
         self.assertRaises(StopIteration, result.next)
 
@@ -394,11 +394,11 @@ class SQLSplitterTests(TestCase):
                END;''')
         s3 = "BEGIN\nFOR i IN 1..10 LOOP\nIF MOD(i,2) = 0 THEN\nINSERT INTO temp VALUES (i, x, 'i is even');ELSE\nINSERT INTO temp VALUES (i, x, 'i is odd');END IF;x := x + 100;END LOOP;COMMIT;END;"
         result = splitSQLString(sql + sqlfn + plsql)
-        r1 = result.next()
+        r1 = next(result)
         self.assertEquals(r1, sql.rstrip(";"))
-        r2 = result.next()
+        r2 = next(result)
         self.assertEquals(r2, sqlfn.rstrip(";"))
-        r3 = result.next()
+        r3 = next(result)
         self.assertEquals(r3, s3)
         self.assertRaises(StopIteration, result.next)
 
@@ -456,9 +456,9 @@ for update skip locked;result integer;begin
 open c1;fetch c1 into result;close c1;return result;end;"""
 
         result = splitSQLString(plsql)
-        r1 = result.next()
+        r1 = next(result)
         self.assertEquals(r1, s1)
-        r2 = result.next()
+        r2 = next(result)
         self.assertEquals(r2, s2)
         self.assertRaises(StopIteration, result.next)
 
@@ -517,12 +517,12 @@ open c1;fetch c1 into result;close c1;return result;end;"""
         s3 = 'create index CALENDAR_OBJECT_ICALE_82e731d5 on CALENDAR_OBJECT (\n    ICALENDAR_UID\n)'
         s4 = "update CALENDARSERVER set VALUE = '17' where NAME = 'VERSION'"
         result = splitSQLString(realsql)
-        r1 = result.next()
+        r1 = next(result)
         self.assertEquals(r1, s1)
-        r2 = result.next()
+        r2 = next(result)
         self.assertEquals(r2, s2)
-        r3 = result.next()
+        r3 = next(result)
         self.assertEquals(r3, s3)
-        r4 = result.next()
+        r4 = next(result)
         self.assertEquals(r4, s4)
         self.assertRaises(StopIteration, result.next)

--- a/txdav/common/datastore/test/util.py
+++ b/txdav/common/datastore/test/util.py
@@ -649,9 +649,9 @@ def assertProvides(testCase, interface, provider):
     """
     try:
         verifyObject(interface, provider)
-    except BrokenMethodImplementation, e:
+    except BrokenMethodImplementation as e:
         testCase.fail(e)
-    except DoesNotImplement, e:
+    except DoesNotImplement as e:
         testCase.fail("%r does not provide %s.%s" %
                       (provider, interface.__module__, interface.getName()))
 

--- a/txdav/common/datastore/upgrade/migrate.py
+++ b/txdav/common/datastore/upgrade/migrate.py
@@ -263,7 +263,7 @@ class UpgradeToDatabaseStep(object):
                     attrs = xattr.xattr(path.path)
                     try:
                         attrs.get('user.should-not-be-set')
-                    except IOError, ioe:
+                    except IOError as ioe:
                         if ioe.errno == errno.ENODATA:
                             # xattrs are supported and enabled on the filesystem
                             # where the calendar data lives.  this takes some

--- a/txdav/common/datastore/upgrade/sql/upgrade.py
+++ b/txdav/common/datastore/upgrade/sql/upgrade.py
@@ -321,7 +321,7 @@ class UpgradeDatabaseSchemaStep(UpgradeDatabaseCoreStep):
             sql = fp.getContent()
             yield sqlTxn.execSQLBlock(sql)
             yield sqlTxn.commit()
-        except (RuntimeError, StandardError) as e:
+        except (RuntimeError, Exception) as e:
             if hasattr(e, "stmt"):
                 self.log.error("Apply upgrade failed for '{basename}' on statement: {stmt}\n{err}".format(
                     basename=fp.basename(),

--- a/txdav/common/datastore/upgrade/sql/upgrades/util.py
+++ b/txdav/common/datastore/upgrade/sql/upgrades/util.py
@@ -175,7 +175,7 @@ def doToEachHomeNotAtVersion(store, homeSchema, version, doIt, logStr, filterOwn
                 Where=homeSchema.RESOURCE_ID == homeResourceID,
             ).on(txn)
             yield txn.commit()
-        except RuntimeError, e:
+        except RuntimeError as e:
             f = Failure()
             logUpgradeError(
                 logStr,

--- a/txdav/dps/client.py
+++ b/txdav/dps/client.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 ##
 # Copyright (c) 2014-2017 Apple Inc. All rights reserved.
 #
@@ -176,7 +177,7 @@ class DirectoryService(BaseDirectoryService, CalendarDirectoryServiceMixin):
         ampProto = (yield self._getConnection())
         try:
             results = (yield ampProto.callRemote(command, **kwds))
-        except Exception, e:
+        except Exception as e:
             log.error("Failed AMP command", error=e)
             #  FIXME: is there a way to hook into ConnectionLost?
             self._connection = None

--- a/txdav/dps/server.py
+++ b/txdav/dps/server.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 ##
 # Copyright (c) 2014-2017 Apple Inc. All rights reserved.
 #
@@ -859,7 +860,7 @@ class DirectoryProxyServiceMaker(object):
                 })
                 manholeService.setServiceParent(multiService)
                 # Using print(because logging isn't ready at this point)
-                print("Manhole access enabled:", portString)
+                print(("Manhole access enabled:", portString))
 
             except ImportError:
                 print(

--- a/txdav/who/augment.py
+++ b/txdav/who/augment.py
@@ -76,7 +76,7 @@ def timed(f):
         """
         startTime = time.time()
         d = f(self, *args, **kwds)
-        d.addBoth(recordTiming, f.func_name, startTime)
+        d.addBoth(recordTiming, f.__name__, startTime)
         return d
 
     return timingWrapper

--- a/txdav/who/groups.py
+++ b/txdav/who/groups.py
@@ -71,7 +71,7 @@ class GroupCacherPollingWork(
             startTime = time.time()
             try:
                 yield groupCacher.update(self.transaction)
-            except Exception, e:
+            except Exception as e:
                 log.error(
                     "Failed to update new group membership cache ({error})",
                     error=e
@@ -96,7 +96,7 @@ class GroupRefreshWork(AggregatedWorkItem, fromTable(schema.GROUP_REFRESH_WORK))
                 yield groupCacher.refreshGroup(
                     self.transaction, self.groupUID.decode("utf-8")
                 )
-            except Exception, e:
+            except Exception as e:
                 log.error(
                     "Failed to refresh group {group} {err}",
                     group=self.groupUID, err=e
@@ -127,7 +127,7 @@ class GroupDelegateChangesWork(AggregatedWorkItem, fromTable(schema.GROUP_DELEGA
                     self.readDelegateUID.decode("utf-8"),
                     self.writeDelegateUID.decode("utf-8")
                 )
-            except Exception, e:
+            except Exception as e:
                 log.error(
                     "Failed to apply external delegates for {uid} {err}",
                     uid=self.delegatorUID, err=e

--- a/txdav/who/wiki.py
+++ b/txdav/who/wiki.py
@@ -390,7 +390,7 @@ def uidForAuthToken(token, descriptor):
     jsonResponse = (yield _getPage(url, descriptor))
     try:
         response = json.loads(jsonResponse)
-    except Exception, e:
+    except Exception as e:
         log.error(
             "Error parsing JSON response from webauth: {resp} {error}",
             resp=jsonResponse, error=str(e)

--- a/txdav/xml/parser_etree.py
+++ b/txdav/xml/parser_etree.py
@@ -160,7 +160,7 @@ class WebDAVDocument(AbstractWebDAVDocument):
                 if not data:
                     break
                 parser.feed(data)
-        except XMLParseError, e:
+        except XMLParseError as e:
             raise ValueError(e)
         return parser.close()
 

--- a/txdav/xml/parser_sax.py
+++ b/txdav/xml/parser_sax.py
@@ -121,7 +121,7 @@ class WebDAVContentHandler(xml.sax.handler.ContentHandler):
         # children.
         try:
             element = top["class"](*top["children"], **top["attributes"])
-        except ValueError, e:
+        except ValueError as e:
             e.args = ("%s at %s" % (e.args[0], self.location()),) + e.args[1:]
             raise  # Re-raises modified e, but preserves traceback
 
@@ -161,7 +161,7 @@ class WebDAVDocument(AbstractWebDAVDocument):
 
         try:
             parser.parse(source)
-        except xml.sax.SAXParseException, e:
+        except xml.sax.SAXParseException as e:
             raise ValueError(e)
 
         # handler.dom.root_element.validate()

--- a/txweb2/channel/http.py
+++ b/txweb2/channel/http.py
@@ -659,7 +659,7 @@ class HTTPChannelRequest(HTTPParser):
         This method is not intended for users.
         """
         if not self.queued:
-            raise RuntimeError, "noLongerQueued() got called unnecessarily."
+            raise RuntimeError("noLongerQueued() got called unnecessarily.")
 
         self.queued = 0
 
@@ -683,7 +683,7 @@ class HTTPChannelRequest(HTTPParser):
         """
 
         if self.producer:
-            raise ValueError, "registering producer %s before previous one (%s) was unregistered" % (producer, self.producer)
+            raise ValueError("registering producer %s before previous one (%s) was unregistered" % (producer, self.producer))
 
         self.producer = producer
 

--- a/txweb2/dav/method/acl.py
+++ b/txweb2/dav/method/acl.py
@@ -64,7 +64,7 @@ def http_ACL(self, request):
     yield doc
     try:
         doc = doc.getResult()
-    except ValueError, e:
+    except ValueError as e:
         log.error("Error while handling ACL body: %s" % (e,))
         raise HTTPError(StatusResponse(responsecode.BAD_REQUEST, str(e)))
 

--- a/txweb2/dav/method/mkcol.py
+++ b/txweb2/dav/method/mkcol.py
@@ -73,7 +73,7 @@ def http_MKCOL(self, request):
     yield x
     try:
         x.getResult()
-    except ValueError, e:
+    except ValueError as e:
         log.error("Error while handling MKCOL body: %s" % (e,))
         raise HTTPError(responsecode.UNSUPPORTED_MEDIA_TYPE)
 

--- a/txweb2/dav/method/propfind.py
+++ b/txweb2/dav/method/propfind.py
@@ -69,7 +69,7 @@ def http_PROPFIND(self, request):
         doc = waitForDeferred(davXMLFromStream(request.stream))
         yield doc
         doc = doc.getResult()
-    except ValueError, e:
+    except ValueError as e:
         log.error("Error while handling PROPFIND body: %s" % (e,))
         raise HTTPError(StatusResponse(responsecode.BAD_REQUEST, str(e)))
 

--- a/txweb2/dav/method/proppatch.py
+++ b/txweb2/dav/method/proppatch.py
@@ -61,7 +61,7 @@ def http_PROPPATCH(self, request):
         doc = waitForDeferred(davXMLFromStream(request.stream))
         yield doc
         doc = doc.getResult()
-    except ValueError, e:
+    except ValueError as e:
         log.error("Error while handling PROPPATCH body: %s" % (e,))
         raise HTTPError(StatusResponse(responsecode.BAD_REQUEST, str(e)))
 
@@ -125,7 +125,7 @@ def http_PROPPATCH(self, request):
                     x = waitForDeferred(action(property, request))
                     yield x
                     x.getResult()
-                except KeyError, e:
+                except KeyError as e:
                     # Removing a non-existent property is OK according to WebDAV
                     if removing:
                         responses.add(responsecode.OK, property)

--- a/txweb2/dav/method/report.py
+++ b/txweb2/dav/method/report.py
@@ -85,7 +85,7 @@ def http_REPORT(self, request):
         doc = waitForDeferred(davXMLFromStream(request.stream))
         yield doc
         doc = doc.getResult()
-    except ValueError, e:
+    except ValueError as e:
         log.error("Error while handling REPORT body: %s" % (e,))
         raise HTTPError(StatusResponse(responsecode.BAD_REQUEST, str(e)))
 

--- a/txweb2/dav/resource.py
+++ b/txweb2/dav/resource.py
@@ -745,7 +745,7 @@ class DAVResource (DAVPropertyMixIn, StaticRenderMixin):
             childpath = joinURL(basepath, urllib.quote(childname))
             try:
                 child = (yield request.locateChildResource(self, childname))
-            except HTTPError, e:
+            except HTTPError as e:
                 log.error("Resource cannot be located: %s" % (str(e),))
                 if unavailablecallback:
                     unavailablecallback(childpath)
@@ -1491,7 +1491,7 @@ class DAVResource (DAVPropertyMixIn, StaticRenderMixin):
 
         try:
             acl = self.readDeadProperty(element.ACL)
-        except HTTPError, e:
+        except HTTPError as e:
             assert e.response.code == responsecode.NOT_FOUND, (
                 "Expected %s response from readDeadProperty() exception, "
                 "not %s"
@@ -1910,7 +1910,7 @@ class DAVResource (DAVPropertyMixIn, StaticRenderMixin):
             def gotPrincipal(principal):
                 try:
                     principal = principal.getResult()
-                except HTTPError, e:
+                except HTTPError as e:
                     assert e.response.code == responsecode.NOT_FOUND, (
                         "%s (!= %s) status from readProperty() exception"
                         % (e.response.code, responsecode.NOT_FOUND)

--- a/txweb2/dav/test/test_xattrprops.py
+++ b/txweb2/dav/test/test_xattrprops.py
@@ -57,7 +57,7 @@ class ExtendedAttributesPropertyStoreTests(TestCase):
         self.resourcePath.parent().chmod(0)
         # Make sure to restore access to it later so that it can be deleted
         # after the test run is finished.
-        self.addCleanup(self.resourcePath.parent().chmod, 0700)
+        self.addCleanup(self.resourcePath.parent().chmod, 0o700)
 
         # Try to get a property from it - and fail.
         document = self._makeValue()
@@ -76,7 +76,7 @@ class ExtendedAttributesPropertyStoreTests(TestCase):
         self.resourcePath.parent().chmod(0)
         # Make sure to restore access to it later so that it can be deleted
         # after the test run is finished.
-        self.addCleanup(self.resourcePath.parent().chmod, 0700)
+        self.addCleanup(self.resourcePath.parent().chmod, 0o700)
 
         # Try to get a property from it - and fail.
         document = self._makeValue()
@@ -330,7 +330,7 @@ class ExtendedAttributesPropertyStoreTests(TestCase):
         self.resourcePath.parent().chmod(0)
         # Make sure to restore access to it later so that it can be deleted
         # after the test run is finished.
-        self.addCleanup(self.resourcePath.parent().chmod, 0700)
+        self.addCleanup(self.resourcePath.parent().chmod, 0o700)
 
         # Try to get a property from it - and fail.
         self._makeValue()

--- a/txweb2/dav/test/tworequest_client.py
+++ b/txweb2/dav/test/tworequest_client.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import socket
 import sys
 
@@ -17,25 +18,25 @@ else:
     send = s.send
     recv = s.recv
 
-print >> sys.stderr, ">> Making %s request to port %d" % (socket_type, port)
+print(">> Making %s request to port %d" % (socket_type, port), file=sys.stderr)
 
 send("PUT /forbidden HTTP/1.1\r\n")
 send("Host: localhost\r\n")
 
-print >> sys.stderr, ">> Sending lots of data"
+print(">> Sending lots of data", file=sys.stderr)
 send("Content-Length: 100\r\n\r\n")
 send("X" * 100)
 
 send("PUT /forbidden HTTP/1.1\r\n")
 send("Host: localhost\r\n")
 
-print >> sys.stderr, ">> Sending lots of data"
+print(">> Sending lots of data", file=sys.stderr)
 send("Content-Length: 100\r\n\r\n")
 send("X" * 100)
 
 # import time
 # time.sleep(5)
-print >> sys.stderr, ">> Getting data"
+print(">> Getting data", file=sys.stderr)
 data = ''
 while len(data) < 299999:
     try:

--- a/txweb2/dav/test/util.py
+++ b/txweb2/dav/test/util.py
@@ -343,7 +343,7 @@ def serialize(f, work):
 
     def do_serialize(_):
         try:
-            args = work.next()
+            args = next(work)
         except StopIteration:
             d.callback(None)
         else:

--- a/txweb2/dav/xattrprops.py
+++ b/txweb2/dav/xattrprops.py
@@ -142,7 +142,7 @@ class xattrPropertyStore (object):
                 responsecode.NOT_FOUND,
                 "No such property: %s" % (encodeXMLName(*qname),)
             ))
-        except IOError, e:
+        except IOError as e:
             if e.errno in _ATTR_MISSING or e.errno == errno.ENOENT:
                 raise HTTPError(StatusResponse(
                     responsecode.NOT_FOUND,
@@ -229,7 +229,7 @@ class xattrPropertyStore (object):
                 self.attrs.remove(key)
             except KeyError:
                 pass
-            except IOError, e:
+            except IOError as e:
                 if e.errno not in _ATTR_MISSING:
                     raise
         except:
@@ -256,7 +256,7 @@ class xattrPropertyStore (object):
             self.attrs.get(key)
         except KeyError:
             return False
-        except IOError, e:
+        except IOError as e:
             if e.errno in _ATTR_MISSING or e.errno == errno.ENOENT:
                 return False
             raise HTTPError(StatusResponse(
@@ -280,7 +280,7 @@ class xattrPropertyStore (object):
         prefix = self.deadPropertyXattrPrefix
         try:
             attrs = iter(self.attrs)
-        except IOError, e:
+        except IOError as e:
             if e.errno == errno.ENOENT:
                 return []
             raise HTTPError(StatusResponse(

--- a/txweb2/fileupload.py
+++ b/txweb2/fileupload.py
@@ -340,7 +340,7 @@ def parse_urlencoded_stream(
     while still_going:
         try:
             yield input.wait
-            data = input.next()
+            data = next(input)
         except StopIteration:
             pairs = [lastdata]
             still_going = 0

--- a/txweb2/filter/gzip.py
+++ b/txweb2/filter/gzip.py
@@ -30,7 +30,7 @@ def gzipStream(input, compressLevel=6):
         yield input.wait
 
     yield compress.flush()
-    yield struct.pack('<LL', crc & 0xFFFFFFFFL, size & 0xFFFFFFFFL)
+    yield struct.pack('<LL', crc & 0xFFFFFFFF, size & 0xFFFFFFFF)
 gzipStream = stream.generatorToStream(gzipStream)
 
 

--- a/txweb2/filter/range.py
+++ b/txweb2/filter/range.py
@@ -12,14 +12,13 @@ class UnsatisfiableRangeRequest(Exception):
     pass
 
 
-def canonicalizeRange((start, end), size):
+def canonicalizeRange(xxx_todo_changeme, size):
     """Return canonicalized (start, end) or raises UnsatisfiableRangeRequest
     exception.
 
     NOTE: end is the last byte *inclusive*, which is not the usual convention
     in python! Be very careful! A range of 0,1 should return 2 bytes."""
-
-    # handle "-500" ranges
+    (start, end) = xxx_todo_changeme
     if start is None:
         start = max(0, size - end)
         end = None

--- a/txweb2/http_headers.py
+++ b/txweb2/http_headers.py
@@ -392,7 +392,7 @@ def parseKeyValue(val):
 
 def parseArgs(field):
     args = split(field, Token(';'))
-    val = args.next()
+    val = next(args)
     args = [parseKeyValue(arg) for arg in args]
     return val, args
 
@@ -656,7 +656,7 @@ def parseContentDisposition(header):
 def parseContentMD5(header):
     try:
         return base64.decodestring(header)
-    except Exception, e:
+    except Exception as e:
         raise ValueError(e)
 
 
@@ -864,7 +864,8 @@ def parseCacheControl(kv):
     return k, v
 
 
-def generateCacheControl((k, v)):
+def generateCacheControl(xxx_todo_changeme):
+    (k, v) = xxx_todo_changeme
     if v is None:
         return str(k)
     else:

--- a/txweb2/log.py
+++ b/txweb2/log.py
@@ -139,7 +139,7 @@ class BaseCommonAccessLoggingObserver(object):
     logFormat = '%s - %s [%s] "%s" %s %d "%s" "%s"'
 
     def logMessage(self, message):
-        raise NotImplemented, 'You must provide an implementation.'
+        raise NotImplemented('You must provide an implementation.')
 
     def computeTimezoneForLog(self, tz):
         if tz > 0:

--- a/txweb2/static.py
+++ b/txweb2/static.py
@@ -128,7 +128,7 @@ class StaticRenderMixin(resource.RenderMixin, MetaDataMixin):
         """
         try:
             response = yield super(StaticRenderMixin, self).renderHTTP(request)
-        except HTTPError, he:
+        except HTTPError as he:
             response = he.response
 
         response = iweb.IResponse(response)
@@ -436,7 +436,7 @@ class File(StaticRenderMixin):
 
         try:
             f = self.fp.open()
-        except IOError, e:
+        except IOError as e:
             import errno
             if e[0] == errno.EACCES:
                 return responsecode.FORBIDDEN
@@ -467,7 +467,7 @@ class FileSaver(resource.PostableResource):
                     http_headers.MimeType('text', 'html'),
                     http_headers.MimeType('text', 'css'))
 
-    def __init__(self, destination, expectedFields=[], allowedTypes=None, maxBytes=1000000, permissions=0644):
+    def __init__(self, destination, expectedFields=[], allowedTypes=None, maxBytes=1000000, permissions=0o644):
         self.destination = destination
         self.allowedTypes = allowedTypes or self.allowedTypes
         self.maxBytes = maxBytes
@@ -528,7 +528,7 @@ class FileSaver(resource.PostableResource):
                         try:
                             outname = self.writeFile(*finfo)
                             content.append("Saved file %s<br />" % outname)
-                        except IOError, err:
+                        except IOError as err:
                             content.append(str(err) + "<br />")
                 else:
                     content.append("%s is not a valid field" % fieldName)

--- a/txweb2/stream.py
+++ b/txweb2/stream.py
@@ -312,7 +312,7 @@ class MemoryStream(SimpleStream):
         SimpleStream.close(self)
 
 components.registerAdapter(MemoryStream, str, IByteStream)
-components.registerAdapter(MemoryStream, types.BufferType, IByteStream)
+components.registerAdapter(MemoryStream, memoryview, IByteStream)
 
 #
 # CompoundStream
@@ -935,7 +935,7 @@ class _IteratorStream(object):
 
     def read(self):
         try:
-            val = self._gen.next()
+            val = next(self._gen)
         except StopIteration:
             return None
         else:

--- a/txweb2/test/simple_client.py
+++ b/txweb2/test/simple_client.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import socket
 import sys
 
@@ -17,13 +18,13 @@ else:
     send = s.send
     recv = s.recv
 
-print >> sys.stderr, ">> Making %s request to port %d" % (socket_type, port)
+print(">> Making %s request to port %d" % (socket_type, port), file=sys.stderr)
 
 send("GET /error HTTP/1.0\r\n")
 send("Host: localhost\r\n")
 
 if test_type == "lingeringClose":
-    print >> sys.stderr, ">> Sending lots of data"
+    print(">> Sending lots of data", file=sys.stderr)
     send("Content-Length: 1000000\r\n\r\n")
     send("X" * 1000000)
 else:
@@ -31,7 +32,7 @@ else:
 
 # import time
 # time.sleep(5)
-print >> sys.stderr, ">> Getting data"
+print(">> Getting data", file=sys.stderr)
 data = ''
 while len(data) < 299999:
     try:

--- a/txweb2/test/test_http.py
+++ b/txweb2/test/test_http.py
@@ -41,7 +41,7 @@ class PreconditionTestCase(unittest.TestCase):
 
         try:
             http.checkPreconditions(request, response, **kw)
-        except http.HTTPError, e:
+        except http.HTTPError as e:
             preconditionsPass = False
             self.assertEquals(e.response.code, expectedCode)
         self.assertEquals(preconditionsPass, expectedResult)

--- a/txweb2/test/test_server.py
+++ b/txweb2/test/test_server.py
@@ -270,7 +270,8 @@ class BaseCase(unittest.TestCase):
 
         return d
 
-    def _cbGotResponse(self, (code, headers, data, failed), expected_response, expectedfailure=False):
+    def _cbGotResponse(self, xxx_todo_changeme, expected_response, expectedfailure=False):
+        (code, headers, data, failed) = xxx_todo_changeme
         expected_code, expected_headers, expected_data = expected_response
         self.assertEquals(code, expected_code)
         if expected_data is not None:

--- a/txweb2/test/test_static.py
+++ b/txweb2/test/test_static.py
@@ -93,9 +93,10 @@ Content-Type: %s\r
 -----weeboundary--\r
 """ % (fieldname, filename, mimetype, content))
 
-    def _CbAssertInResponse(self, (code, headers, data, failed),
+    def _CbAssertInResponse(self, xxx_todo_changeme,
                             expected_response, expectedFailure=False):
 
+        (code, headers, data, failed) = xxx_todo_changeme
         expected_code, expected_headers, expected_data = expected_response
         self.assertEquals(code, expected_code)
 


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3. There will _definitely_ be more work required to complete the port to Python 3 but this is a minimal, safe first step.

Run: `futurize --stage1 -w **/*.py`  # done in zsh for ** globbing

See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes

$ `pip install future`
$ `git checkout -b modernize-python2-code`
$ `futurize --stage1 -w **/*.py`  # done in zsh for ** globbing
$ `git commit --all -m "Modernize Python 2 code to get ready for Python 3"`
$ `git push --set-upstream origin modernize-python2-code`