### PR TITLE
ccs-calendarserver: Address build issues with newer dependencies

### DIFF
--- a/bin/_build.sh
+++ b/bin/_build.sh
@@ -523,13 +523,13 @@ c_dependencies () {
     if [ "${ssl_version}" -ge "${min_ssl_version}" ]; then
       using_system "OpenSSL";
     else
-      local v="1.0.2h";
+      local v="1.0.2r";
       local n="openssl";
       local p="${n}-${v}";
 
       # use 'config' instead of 'configure'; 'make' instead of 'jmake'.
       # also pass 'shared' to config to build shared libs.
-      c_dependency -c "config" -s "577585f5f5d299c44dd3c993d3c0ac7a219e4949" \
+      c_dependency -c "config" -s "b9aec1fa5cedcfa433aed37c8fe06b0ab0ce748d" \
         -p "make depend" -b "make" \
         "openssl" "${p}" \
         "http://www.openssl.org/source/${p}.tar.gz" "shared";

--- a/requirements-cs.txt
+++ b/requirements-cs.txt
@@ -17,7 +17,7 @@
                 #setuptools
 
         # [DAL] extra
-              sqlparse==0.2.0
+              sqlparse==0.2.4
 
         # [OpenDirectory] extra
             #pyobjc-framework-OpenDirectory  # Use system module


### PR DESCRIPTION
ccs-calendarserver: Address build issues with newer dependencies

* Update to openssl 1.0.2r
* Update to sqlparse 0.2.4 in ./requirements-cs.txt
* **WARNING**: Does not yet address `invoke './Configure darwin64-x86_64-cc' *manually*` in `.develop/src/openssl-1.0.2r/config`, `ld: symbol(s) not found for architecture i386` errors
* See: https://github.com/apple/ccs-twistedextensions/pull/20
* See: https://gist.github.com/essandess/4c9b5d906896ff4aef6170fc18f2c293

Comments:
* OpenSSL build issues may be sidestepped by using the MacPorts (or other) openssl installs as system libraries. This is preferred to using a package-specific library that may not be upgraded as regularly as its dependency. Working example that yields a successful run of `./bin/package /path/to/CalendarServer`:
```
cat <<PACKAGE_CALENDARSERVER | sh -x
(
    export PATH=/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
    export C_INCLUDE_PATH=/opt/local/include:/usr/include:/usr/local/include
    export LD_LIBRARY_PATH=/opt/local/lib:/opt/local/lib/openssl-1.0:/usr/lib:/usr/local/lib
    export CPPFLAGS='-I/opt/local/include -I/usr/include -I/usr/local/include'
    export LDFLAGS='-L/opt/local/lib -L/opt/local/lib/openssl-1.0 -L/usr/lib -L/usr/local/lib'
    export DYLD_LIBRARY_PATH=/opt/local/lib:/opt/local/lib/openssl-1.0:/usr/lib:/usr/local/lib

    ./bin/package -F /private/var/calendarserver/Library/CalendarServer 1> ~/ccs-calendarserver.log 2>&1
)
PACKAGE_CALENDARSERVER
```

By submitting a request, you represent that you have the right to license
your contribution to Apple and the community, and agree that your
contributions are licensed under the [Apache License Version 2.0](LICENSE.txt).

For existing files modified by your request, you represent that you have
retained any existing copyright notices and licensing terms. For each new
file in your request, you represent that you have added to the file a
copyright notice (including the year and the copyright owner's name) and the
Calendar and Contacts Server's licensing terms.

Before submitting the request, please make sure that your request follows
the [Calendar and Contacts Server's guidelines for contributing
code](../../../ccs-calendarserver/blob/master/HACKING.rst).