### PR TITLE
Add optional SNI support via TxSNI library from pypi

### DIFF
--- a/conf/caldavd-stdconfig.plist
+++ b/conf/caldavd-stdconfig.plist
@@ -742,6 +742,17 @@
 
 	<!-- SSL/TLS -->
 
+	<key>SNIMode</key>
+	<false/>
+
+	<!-- Directory for housing combined key/cert/CAcert files indexed by hostname -->
+	<key>SSLDir</key>
+	<string></string>
+
+	<!-- Combined key/cert/CAcert file to fall back to when no hostname provided -->
+	<key>DefaultSSLBundle</key>
+	<string></string>
+
 	<!-- Public key -->
 	<key>SSLCertificate</key>
 	<string></string>

--- a/conf/caldavd.plist
+++ b/conf/caldavd.plist
@@ -300,6 +300,18 @@
         SSL/TLS
       -->
 
+    <!-- Whether or not to enable SNI for CCS. If yes, configure DefaultSSLBundle & SSLDir. If not, configure the rest of the keys here -->
+    <key>SNIMode</key>
+    <false/>
+
+    <!-- "Default" combined key/cert/CAcert file to use when SNI is active -->
+    <key>DefaultSSLBundle</key>
+    <string></string>
+
+    <!-- Combined key/cert/CAcert SSL bundle directory when SNI is active (indexed by host) -->
+    <key>SSLDir</key>
+    <string></string>
+
     <!-- Public key -->
     <key>SSLCertificate</key>
     <string></string>

--- a/requirements-twisted-default.txt
+++ b/requirements-twisted-default.txt
@@ -30,3 +30,5 @@ Twisted==16.6.0
 
     incremental==16.10.1
     constantly==15.1
+
+TxSNI==0.1.9

--- a/twistedcaldav/stdconfig.py
+++ b/twistedcaldav/stdconfig.py
@@ -489,6 +489,9 @@ DEFAULT_CONFIG = {
     #
     # SSL/TLS
     #
+    "SNIMode": False,
+    "SSLDir": "", # Directory for housing combined key/cert/CAcert files indexed by hostname
+    "DefaultSSLBundle": "", # Combined key/cert/CAcert file to fall back to when no hostname provided
     "SSLCertificate": "",  # Public key
     "SSLPrivateKey": "",  # Private key
     "SSLAuthorityChain": "",  # Certificate Authority Chain


### PR DESCRIPTION
Three configuration options are added to caldavd.plist to make this work:
* SNIMode (BOOL): Whether to use SNI. If not, falls back to old SSL code.
* SSLDir (STRING): Directory where all the key/cert/CAcert bundle .pem
  files live, indexed by hostname
* DefaultSSLBundle (STRING): What file to load as certificate when no
  hostname has been indicated by the client when connecting or no cert
  exists for the given host.

Certificate structure will be as such:
~~~
|_DirectoryNameIConfiguredInCaldavd.plist
  |_my.supercool.host.pem
  |_some.other.host.pem
  |_...
~~~

Symlinks also work if you have multiple domains covered on a single
cert.

CAVEATS: This mode of operation assumes that no certificates were
generated with keys that are protected by passphrases. The old
code which exists to account for this won't help you in SNI mode, as we
no longer go down those code paths (TxSNI doesn't appear to support
that, though with SNI it does sound somewhat hairy to have to deal with
for potentially a *lot* of certs).

No updates to the testsuite have been made for this change.
Considering that I didn't break the old pathways for SSL/TLS (and that
this doesn't appear to break the current testsuite), I thought that to be
an acceptable way to implement this, as this is my first real foray into
python (and I'm not really all that familiar with the test harness that
is in user here, much less proper mocking techniques for python tests).